### PR TITLE
Preliminary CAT instructions and some tweaks in CAT translations

### DIFF
--- a/www/languages/pl/forms/adaptive/uniSettings&translations.csv
+++ b/www/languages/pl/forms/adaptive/uniSettings&translations.csv
@@ -1,23 +1,22 @@
 text_type;text
 cdiNamePrefix;Inwentarz Rozwoju Mowy i Komunikacji
-cdiNameSufix;wersja adaptatywna
 birthQuestion;Data urodzenia dziecka
 genderQuestion;Płeć dziecka
 genders;dziewczynka,chłopiec
 btn;Start
 noGender;Proszę wybrać płeć dziecka.
 modalTitle;Uwaga!
-testInstr;Proszę odpowiedzieć na pytanie.
-choiceNames;Nie, Tak
+testInstr;Proszę zaznaczyć ‚tak’ lub ‚nie’.
+choiceNames;nie, tak
 thanks;Dziękujemy za wypełnienie inwentarza!
 end;Koniec!
-alreadyFilled;Ten inwentarz został już przez Ciebie wypełniony.
+alreadyFilled;Ten inwentarz został już przez Państwa wypełniony.
 fillerQuestion;Kim Państwo są dla dziecka?
 fillers;mama,tata,babcia,dziadek,niania,nauczyciel(-ka),inna odpowiedź (proszę wpisać):
 noFiller;Proszę wybrać osobę, która wypełnia kwestionariusz
 email;yes
-error;Wystąpił błąd. Proszę odświeżyć i spróbować ponownie. Jeśli błąd się powtarza prosimy o zrobienie screena tego komunikatu i wysłanie na maila projekt.starwords@psych.uw.edu.pl lub przez media społecznościowe.
+error;Wystąpił błąd. Proszę odświeżyć i spróbować ponownie. Jeśli błąd się powtarza, prosimy o zrobienie screena tego komunikatu i wysłanie do nas na maila projekt.starwords@psych.uw.edu.pl lub przez media społecznościowe.
 refresh;Odśwież
 commentLabel;Uwagi
-endText;Koniec testu. Proszę nacisnąć przycisk, aby zakończyć.
+endText;Proszę nacisnąć ‚Zakończ’, aby zakończyć.
 endBtn;Zakończ

--- a/www/languages/pl/forms/adaptive/wg-cat/settings&translations.csv
+++ b/www/languages/pl/forms/adaptive/wg-cat/settings&translations.csv
@@ -1,16 +1,17 @@
 text_type;text
+cdiNameSufix;Wersja adaptatywna dla rodziców młodszych dzieci
 groups;mowa,rozumienie,gesty
 rozumienieMirtMethod;ML
 rozumienieMirtCriteria;MI
-rozumienieHeader;Rozumienie słów
+rozumienieHeader;Rozumienie
 rozumienieHeaderColor;lightsalmon
 gestyMirtMethod;ML
 gestyMirtCriteria;MI
-gestyHeader;Gesty
+gestyHeader;Czynności i gesty
 gestyHeaderColor;lightsteelblue
 mowaMirtMethod;ML
 mowaMirtCriteria;MI
-mowaHeader;Produkcja słów
+mowaHeader;Mowa
 mowaHeaderColor;lightgreen
 rozumienieMirtSeTheta;0.05
 mowaMirtSeTheta;0.05
@@ -22,6 +23,6 @@ rozumienieminItemNr;1
 mowaminItemNr;1
 gestyminItemNr;1
 continueBtn;Dalej
-rozumienieInstr;Proszę zaznaczać “tak”, jeśli twoje dziecko rozumie podane słowo
-gestyInstr;Proszę zaznaczać “tak”, jeśli twoje dziecko wykonuje podany gest
-mowaInstr;Proszę zaznaczać “tak”, jeśli twoje dziecko mówi podane słowo
+rozumienieInstr;Po kliknięciu przycisku ‚Dalej’ zobaczą Państwo typowe wyrazy znane małym dzieciom i przy każdym będą Państwo proszeni o odpowiedź na pytanie, czy Państwa dziecko rozumie to słowo. Proszę pamiętać, że IRMIK opiera się na wiedzy rodziców (lub innych opiekunów) na temat rozwoju językowego dzieci. Proszę nie przepytywać dziecka. Wystarczy, gdy odpowiedzą Państwo na pytania według własnej wiedzy o dziecku. Na końcu pojawi się pole na uwagi, które mogą Państwo wykorzystać, żeby podzielić się z nami wszelkimi wątpliwościami.
+gestyInstr;Kiedy dzieci uczą się porozumiewać z innymi ludźmi, często posługują się gestami, aby wyrazić swoje pragnienia. Często też naśladują dorosłych nie tylko w mowie, ale również w zabawie, udając np. czynności opiekuńcze. Przy każdym z gestów i każdej z czynności, które pojawią się po kliknięciu przycisku ‚Dalej’, proszę zaznaczyć ‚tak’ przy tym określeniu, które pasuje do tego, co Państwa dziecko aktualnie robi. Na końcu pojawi się pole na uwagi, które mogą Państwo wykorzystać, żeby podzielić się z nami wszelkimi wątpliwościami.
+mowaInstr;"Po kliknięciu przycisku ‚Dalej’ zobaczą Państwo typowe wyrazy znane małym dzieciom i przy każdym będą Państwo proszeni o odpowiedź na pytanie, czy Państwa dziecko mówi to słowo spontanicznie. Nie chodzi o to, co dziecko jest w stanie powtórzyć, ale o słowa, których samo z siebie używa. Proszę zaznaczyć ‚tak’ tylko przy tych słowach, które słyszeli Państwo od swego dziecka. Jeżeli dziecko używa nieco innej formy, np. mówi „piesek”, a nie „pies”, proszę mimo to zaznaczyć ‚tak’ przy słowie „pies”. Tak samo należy postąpić, jeśli dziecko wymawia jakieś słowo inaczej (np. „lybka” zamiast „rybka” lub „wiójka” zamiast „wiewiórka”). Proszę wtedy również zaznaczyć ‚tak’. Czasami dzieci wymyślają własne wyrazy, np. „dzi” zamiast „piłka”; także taką formę należy potraktować jako wyraz i zaznaczyć ‚tak’ przy słowie „piłka”. Podobnie, jeśli w rodzinie funkcjonuje inne określenie niż podane w kwestionariuszu, proszę zaznaczyć odpowiednią pozycję. Jeśli będą Państwo chcieli, w polu na uwagi, które pojawi się na końcu, mogą Państwo wpisać wszystkie te wyrazy w takiej formie, w jakiej ich Państwa dziecko używa. Mogą Państwo również wykorzystać to pole, żeby podzielić się z nami wszelkimi wątpliwości. Proszę pamiętać, że IRMIK opiera się na wiedzy rodziców (lub innych opiekunów) na temat rozwoju językowego dzieci. Proszę nie przepytywać dziecka ani go nie prosić o powtarzanie poszczególnych wyrazów. Wystarczy, gdy odpowiedzą Państwo na pytania według własnej wiedzy o dziecku."

--- a/www/languages/pl/forms/adaptive/ws-cat/items.csv
+++ b/www/languages/pl/forms/adaptive/ws-cat/items.csv
@@ -1,668 +1,668 @@
-,a1,d,item,question
-item1,1.23138524388075,0.405483351886401,gę gę,Czy Twoje dziecko mówi
-item2,1.35386870628754,2.89042878862175,hau hau,Czy Twoje dziecko mówi
-item3,1.22826577610391,2.12653266696281,ko ko ko,Czy Twoje dziecko mówi
-item4,1.52956729905576,1.49589133582856,kwa kwa,Czy Twoje dziecko mówi
-item5,1.39348290633965,2.77438117056279,miau,Czy Twoje dziecko mówi
-item6,1.29965654481926,1.64131548456154,mee bee,Czy Twoje dziecko mówi
-item7,1.38365125894468,2.47799291781542,muu  krowa ,Czy Twoje dziecko mówi
-item8,1.1271224958264,0.715550049560748,pi pi pi ćwir ćwir,Czy Twoje dziecko mówi
-item9,0.755455622303629,1.38622108095382,bam bum bęc,Czy Twoje dziecko mówi
-item10,0.818206239721638,1.5820247452698,brrum brrum,Czy Twoje dziecko mówi
-item11,1.58479926902752,0.771763380955884,tik tak,Czy Twoje dziecko mówi
-item12,1.13658142225624,0.840238155627176,tralala lalala,Czy Twoje dziecko mówi
-item13,2.43162168388127,-0.218870614469224,baran,Czy Twoje dziecko mówi
-item14,3.62882952331884,0.137726839132282,biedronka,Czy Twoje dziecko mówi
-item15,2.9432330867363,-0.31341206017346,bocian,Czy Twoje dziecko mówi
-item16,2.55893505902479,-0.766382087602793,foka,Czy Twoje dziecko mówi
-item17,2.12431741761044,-0.639900219432973,gęś,Czy Twoje dziecko mówi
-item18,2.58735070485951,-0.778710353942218,gołąb,Czy Twoje dziecko mówi
-item19,2.90281368342521,-0.541206770751403,jeż,Czy Twoje dziecko mówi
-item20,2.6178385869125,1.15883479687528,kaczka,Czy Twoje dziecko mówi
-item21,2.35910614449616,0.078019125261643,kogut,Czy Twoje dziecko mówi
-item22,2.77054561737004,1.73417703375554,koń,Czy Twoje dziecko mówi
-item23,2.58090361223077,3.09827816371303,kot,Czy Twoje dziecko mówi
-item24,2.69283142324546,-0.130413574008895,koza,Czy Twoje dziecko mówi
-item25,2.76151284605267,1.74997289859053,krowa,Czy Twoje dziecko mówi
-item26,3.1766913505227,0.059320439865719,królik,Czy Twoje dziecko mówi
-item27,2.67307351121665,1.81244678386503,kura,Czy Twoje dziecko mówi
-item28,2.12134905640328,-1.28442100368917,kurczątko,Czy Twoje dziecko mówi
-item29,2.84950242409146,0.483737603248925,lew,Czy Twoje dziecko mówi
-item30,2.72763115279214,-0.223388460917203,lis,Czy Twoje dziecko mówi
-item31,3.08102523160744,0.402590355469381,małpa,Czy Twoje dziecko mówi
-item32,2.42472631909309,1.2147326750557,miś niedźwiedź,Czy Twoje dziecko mówi
-item33,3.75382968533949,0.069007855709273,motylek,Czy Twoje dziecko mówi
-item34,3.62990779019329,-0.835985058644601,mrówka,Czy Twoje dziecko mówi
-item35,3.10123410764956,1.26795964165362,mucha,Czy Twoje dziecko mówi
-item36,3.42271540060668,0.621547857592157,myszka,Czy Twoje dziecko mówi
-item37,3.44752937795183,-0.38170467616236,pająk,Czy Twoje dziecko mówi
-item38,2.47865502723727,2.5186180675481,pies,Czy Twoje dziecko mówi
-item39,3.04744864182047,-1.08433278000211,pingwin,Czy Twoje dziecko mówi
-item40,3.17798323641325,0.89328768909845,ptaszek,Czy Twoje dziecko mówi
-item41,3.67074418802879,-0.279127276414981,robak,Czy Twoje dziecko mówi
-item42,3.49095219457203,1.49935771340304,ryba,Czy Twoje dziecko mówi
-item43,3.25618446391709,0.518610605376144,słoń,Czy Twoje dziecko mówi
-item44,2.61705103136815,-0.317884017628774,sowa,Czy Twoje dziecko mówi
-item45,3.70158157111798,-0.267809268928413,ślimak,Czy Twoje dziecko mówi
-item46,3.02503214959037,0.532753352490288,świnka,Czy Twoje dziecko mówi
-item47,2.96606079146206,-0.623095733948568,tygrys,Czy Twoje dziecko mówi
-item48,2.86539778427088,-0.443349494424624,wąż,Czy Twoje dziecko mówi
-item49,3.47395289084047,-0.990159054609545,wiewiórka,Czy Twoje dziecko mówi
-item50,2.96993693359947,-0.701642003614226,wilk,Czy Twoje dziecko mówi
-item51,3.44085693791983,-0.718928057169007,zając,Czy Twoje dziecko mówi
-item52,3.89847589998845,-1.31138318763174,zwierzątko,Czy Twoje dziecko mówi
-item53,3.13465687491241,1.12051006346202,żaba,Czy Twoje dziecko mówi
-item54,3.34808342952557,-0.449956788744654,żółw,Czy Twoje dziecko mówi
-item55,3.35796868757938,-0.430813367310773,żyrafa,Czy Twoje dziecko mówi
-item56,2.79616252987389,3.88208230287244,auto samochód,Czy Twoje dziecko mówi
-item57,2.88781528830459,0.660360166497425,autobus,Czy Twoje dziecko mówi
-item58,2.03878017235658,-0.800085701210405,ciężarówka,Czy Twoje dziecko mówi
-item59,2.25699499671519,-0.895691107523421,helikopter,Czy Twoje dziecko mówi
-item60,2.33668513220646,0.009911210638064,koparka,Czy Twoje dziecko mówi
-item61,1.73854546694524,-0.778693397973674,lokomotywa,Czy Twoje dziecko mówi
-item62,3.06789212427141,0.501512214574968,motor motocykl,Czy Twoje dziecko mówi
-item63,2.67979700459355,1.00787985127384,pociąg,Czy Twoje dziecko mówi
-item64,2.01457503906214,-0.275292270880221,pogotowie karetka,Czy Twoje dziecko mówi
-item65,3.85891629232434,1.28797428634207,rower,Czy Twoje dziecko mówi
-item66,3.57332463948002,1.16127706112959,samolot,Czy Twoje dziecko mówi
-item67,3.46039421916528,-0.464990072262524,statek,Czy Twoje dziecko mówi
-item68,2.2379572222947,0.66052632010349,traktor,Czy Twoje dziecko mówi
-item69,2.03043663642895,-1.21135466349216,tramwaj,Czy Twoje dziecko mówi
-item70,3.70036154602374,2.10171506992813,banan,Czy Twoje dziecko mówi
-item71,2.66640733750154,-2.11881781522471,barszcz,Czy Twoje dziecko mówi
-item72,2.84822678520753,-0.627523910500339,batonik,Czy Twoje dziecko mówi
-item73,3.03555239404612,-0.838021095658786,budyń,Czy Twoje dziecko mówi
-item74,3.70077080956808,1.91511184559752,bułka,Czy Twoje dziecko mówi
-item75,3.68167647176701,-1.52311498198694,buraczki,Czy Twoje dziecko mówi
-item76,3.9732103265434,-0.771715248280607,cebula,Czy Twoje dziecko mówi
-item77,4.11440311320864,1.84104693854365,chleb,Czy Twoje dziecko mówi
-item78,3.42173403037943,0.779821625485124,chrupki,Czy Twoje dziecko mówi
-item79,3.05781139494001,0.233761468010514,ciasto,Czy Twoje dziecko mówi
-item80,3.37207924501847,1.01796489717297,ciastko,Czy Twoje dziecko mówi
-item81,3.63751499654773,-0.396852926008033,cukier,Czy Twoje dziecko mówi
-item82,2.96398383247705,0.560610218808009,cukierek,Czy Twoje dziecko mówi
-item83,3.96000868946006,0.72697770387098,czekolada,Czy Twoje dziecko mówi
-item84,3.07121900825454,-0.710882866527126,dżem,Czy Twoje dziecko mówi
-item85,3.50938585689332,-1.63811805158922,galaretka,Czy Twoje dziecko mówi
-item86,3.30630588998007,-1.6698295334219,groszek,Czy Twoje dziecko mówi
-item87,3.29150657210403,-1.26064117484785,grzyby,Czy Twoje dziecko mówi
-item88,2.19909926011273,-0.850692334237665,guma do żucia,Czy Twoje dziecko mówi
-item89,3.53549760845094,0.784457199217357,herbata,Czy Twoje dziecko mówi
-item90,4.49286859723825,1.96841483591151,jabłko,Czy Twoje dziecko mówi
-item91,3.33429078745904,2.67991313025076,jajko,Czy Twoje dziecko mówi
-item92,1.87958679759762,1.68994610161391,jedzenie papu am,Czy Twoje dziecko mówi
-item93,3.40767149089503,-0.015491434734933,jogurt,Czy Twoje dziecko mówi
-item94,2.62495219674413,-0.492927847326598,kakao,Czy Twoje dziecko mówi
-item95,3.85228862913924,-0.284351139879247,kanapka kromka,Czy Twoje dziecko mówi
-item96,4.33621486365009,-1.89373513005856,kapusta,Czy Twoje dziecko mówi
-item97,2.5895931140794,0.065687338305997,kaszka,Czy Twoje dziecko mówi
-item98,3.00116443118882,0.405029502287313,kawa,Czy Twoje dziecko mówi
-item99,3.50225657901622,-0.233038078292935,ketchup,Czy Twoje dziecko mówi
-item100,3.87560906088359,0.094254031119076,kiełbasa,Czy Twoje dziecko mówi
-item101,4.21339077052276,-0.628220634529254,kotlet,Czy Twoje dziecko mówi
-item102,3.85017241020299,-0.575882877559766,kurczak,Czy Twoje dziecko mówi
-item103,3.61334340885481,0.75641557985329,lizak,Czy Twoje dziecko mówi
-item104,3.82893031307262,1.16619915913008,lody,Czy Twoje dziecko mówi
-item105,4.54248226646636,-0.105101147022649,makaron kluski,Czy Twoje dziecko mówi
-item106,3.29679107681756,-1.57421802405547,mandarynka,Czy Twoje dziecko mówi
-item107,5.01570780129269,0.01849807210202,marchewka,Czy Twoje dziecko mówi
-item108,4.51147242024619,-0.462858772455702,masło margaryna,Czy Twoje dziecko mówi
-item109,4.25580202594268,0.298258535538589,mięso,Czy Twoje dziecko mówi
-item110,3.3495944795517,-1.47524264970013,miód,Czy Twoje dziecko mówi
-item111,3.82777199442414,1.88145142575845,mleko,Czy Twoje dziecko mówi
-item112,3.93805597030011,-1.10795471465477,naleśniki,Czy Twoje dziecko mówi
-item113,4.26003663262629,-2.03656952466318,orzechy,Czy Twoje dziecko mówi
-item114,4.15636017655103,0.17346066665398,ogórek,Czy Twoje dziecko mówi
-item115,4.1467126956232,-0.048670817941587,paluszki,Czy Twoje dziecko mówi
-item116,4.25015889798738,0.57177766038788,parówka kiełbaska,Czy Twoje dziecko mówi
-item117,2.63140981407053,1.94819041808443,picie,Czy Twoje dziecko mówi
-item118,3.48643030297562,-1.35273115509687,pierogi,Czy Twoje dziecko mówi
-item119,3.66712160724013,-1.35734040007015,placek,Czy Twoje dziecko mówi
-item120,4.05350428538001,-1.5972770996663,pomarańcza,Czy Twoje dziecko mówi
-item121,4.53893794465695,0.139978605159524,pomidor,Czy Twoje dziecko mówi
-item122,3.26600613687271,-2.34190851027065,rodzynki,Czy Twoje dziecko mówi
-item123,3.96602476936488,-0.47398246516191,rosół,Czy Twoje dziecko mówi
-item124,3.49802257401074,0.732024153704012,ryba,Czy Twoje dziecko mówi
-item125,3.70161889537777,-0.919959679435524,ryż,Czy Twoje dziecko mówi
-item126,4.08487059061328,0.34689565960189,ser,Czy Twoje dziecko mówi
-item127,3.63502302983927,1.41058855994297,sok,Czy Twoje dziecko mówi
-item128,3.1264415586161,-0.824860964086983,sos,Czy Twoje dziecko mówi
-item129,3.56072459525807,-0.87949027645159,sól,Czy Twoje dziecko mówi
-item130,3.70847506832051,-0.948075529478284,szynka,Czy Twoje dziecko mówi
-item131,4.50627737782944,-0.772525904218574,truskawki,Czy Twoje dziecko mówi
-item132,3.55556043431518,-2.10019328418155,witaminy,Czy Twoje dziecko mówi
-item133,3.44413516318343,1.51786913075718,woda,Czy Twoje dziecko mówi
-item134,4.57689794313489,-0.095162581576569,ziemniaki kartofle,Czy Twoje dziecko mówi
-item135,4.58990530512909,1.85281106839536,zupa,Czy Twoje dziecko mówi
-item136,3.58010188515902,2.74615232265816,bajka,Czy Twoje dziecko mówi
-item137,3.87326222445759,1.32879144902213,balonik,Czy Twoje dziecko mówi
-item138,3.61922580788279,-0.816673561605505,grabki,Czy Twoje dziecko mówi
-item139,3.35498549047953,-0.430538535835007,gumka,Czy Twoje dziecko mówi
-item140,4.97485036024411,0.145185812796946,kartka papier,Czy Twoje dziecko mówi
-item141,4.79232715155271,2.25954620499718,klocki,Czy Twoje dziecko mówi
-item142,4.71677550457317,1.51548987017919,kredki,Czy Twoje dziecko mówi
-item143,5.00146657596902,1.00382784665052,książka,Czy Twoje dziecko mówi
-item144,2.02901243242628,1.61628942590715,lalka,Czy Twoje dziecko mówi
-item145,4.79864864900391,-0.016493980396522,łopatka,Czy Twoje dziecko mówi
-item146,5.24199748556152,-1.12490936254764,obrazek,Czy Twoje dziecko mówi
-item147,3.45701357042948,-0.956761723068334,ołówek,Czy Twoje dziecko mówi
-item148,3.5006846967276,2.87939328636091,piłka,Czy Twoje dziecko mówi
-item149,3.33912413799082,0.221099833321611,pisak długopis,Czy Twoje dziecko mówi
-item150,5.31921341753221,-0.993202258361264,prezent,Czy Twoje dziecko mówi
-item151,2.04762049577794,0.497612172111375,smoczek,Czy Twoje dziecko mówi
-item152,5.30581073809855,-0.077512036735751,wiaderko,Czy Twoje dziecko mówi
-item153,5.35398058590273,0.606092334095908,zabawka,Czy Twoje dziecko mówi
-item154,4.8297985071551,0.370993226977647,bluzka,Czy Twoje dziecko mówi
-item155,3.87393580975759,3.00479744042494,buty,Czy Twoje dziecko mówi
-item156,3.76127560605651,-1.53059476987784,chustka,Czy Twoje dziecko mówi
-item157,4.63623789690107,2.4511754345948,czapka,Czy Twoje dziecko mówi
-item158,3.90854085136181,-0.500558424335543,guzik,Czy Twoje dziecko mówi
-item159,4.05331814794583,-0.397693903764823,kalosze gumowce,Czy Twoje dziecko mówi
-item160,3.9084939440826,-1.36190517509009,kapelusz,Czy Twoje dziecko mówi
-item161,4.83884399980748,-0.886953507101918,kieszeń,Czy Twoje dziecko mówi
-item162,4.10913240134152,-1.31003883818332,koszula,Czy Twoje dziecko mówi
-item163,5.65067486485322,1.42848029088935,kurtka,Czy Twoje dziecko mówi
-item164,4.70787914900312,0.471688131613001,majtki,Czy Twoje dziecko mówi
-item165,3.3925211922188,-0.316786039304124,pantofle kapcie,Czy Twoje dziecko mówi
-item166,3.66331997611227,-1.28345779028428,pasek,Czy Twoje dziecko mówi
-item167,3.68800709464829,0.851632547158672,pieluszka pampers,Czy Twoje dziecko mówi
-item168,4.57543754954659,-0.048795958903294,piżama,Czy Twoje dziecko mówi
-item169,4.18769701778991,-0.571823842022659,rajstopy rajtuzy,Czy Twoje dziecko mówi
-item170,4.34049882276578,-0.389387272741751,rękawiczki,Czy Twoje dziecko mówi
-item171,4.84006931171715,1.2172614330003,skarpetki,Czy Twoje dziecko mówi
-item172,5.18062958041206,1.05440190524264,spodnie,Czy Twoje dziecko mówi
-item173,3.90503797950694,-1.04414381138966,sukienka,Czy Twoje dziecko mówi
-item174,4.73146430357083,-1.05612740292325,sweter,Czy Twoje dziecko mówi
-item175,4.54301335876412,-0.434384346663432,szalik,Czy Twoje dziecko mówi
-item176,3.04879713794747,-1.62227650300281,śliniaczek,Czy Twoje dziecko mówi
-item177,4.82605722636323,-0.401168814191889,ubranie,Czy Twoje dziecko mówi
-item178,3.60544912542157,-0.279884791213348,broda,Czy Twoje dziecko mówi
-item179,5.60190585988923,2.5166824038804,brzuch,Czy Twoje dziecko mówi
-item180,4.46695985186373,2.02845464424838,buzia,Czy Twoje dziecko mówi
-item181,3.8791698260206,0.125552198792237,czoło,Czy Twoje dziecko mówi
-item182,3.9385536300404,-1.05613391681908,gardło,Czy Twoje dziecko mówi
-item183,5.77203346099232,2.33239103340999,głowa,Czy Twoje dziecko mówi
-item184,4.64114022228949,0.138537639192172,język,Czy Twoje dziecko mówi
-item185,5.21578396687651,0.078961122542563,kolano,Czy Twoje dziecko mówi
-item186,3.52595829946088,-1.54857778807847,krew,Czy Twoje dziecko mówi
-item187,3.44141093387501,-1.96709619501928,łokieć,Czy Twoje dziecko mówi
-item188,5.27036238597599,2.63421080785661,noga,Czy Twoje dziecko mówi
-item189,4.05831237483107,3.28441309244961,nos,Czy Twoje dziecko mówi
-item190,3.39262246674015,3.35910294298266,oko,Czy Twoje dziecko mówi
-item191,5.16006007101355,1.25607640540455,palec,Czy Twoje dziecko mówi
-item192,5.3054506811203,-0.912190395486372,paznokcie pazurki,Czy Twoje dziecko mówi
-item193,3.39101071757001,0.842993890356853,pępek,Czy Twoje dziecko mówi
-item194,4.91757720843828,-0.114538335778022,plecy,Czy Twoje dziecko mówi
-item195,4.35491786402075,-0.862184716667488,policzek,Czy Twoje dziecko mówi
-item196,3.46762868792203,2.49976038100412,pupa,Czy Twoje dziecko mówi
-item197,5.59644512411004,1.96894717543251,ręka,Czy Twoje dziecko mówi
-item198,3.69680766036274,-1.26998679492531,serce,Czy Twoje dziecko mówi
-item199,4.06167600912195,-2.12403676547492,skóra,Czy Twoje dziecko mówi
-item200,4.12707912358052,-0.142880547807043,szyja,Czy Twoje dziecko mówi
-item201,4.26836693093557,2.38126407507583,ucho,Czy Twoje dziecko mówi
-item202,5.44436613597001,2.06860977406305,włosy,Czy Twoje dziecko mówi
-item203,5.33549320874598,1.14841222148734,ząb,Czy Twoje dziecko mówi
-item204,3.01057236972695,-0.99750868383892,balkon,Czy Twoje dziecko mówi
-item205,3.41841627034266,-0.798258462949491,dach,Czy Twoje dziecko mówi
-item206,4.60485705253676,2.12122634117923,drzwi,Czy Twoje dziecko mówi
-item207,4.80936227695451,-0.25911036515519,dywan,Czy Twoje dziecko mówi
-item208,3.92887786161942,-1.32932515404336,firanka zasłona,Czy Twoje dziecko mówi
-item209,4.35759277227131,-0.167313502891168,fotel,Czy Twoje dziecko mówi
-item210,3.86259645296057,-2.30101477135512,korytarz przedpokój,Czy Twoje dziecko mówi
-item211,4.08366037647805,-1.02970011109032,kran,Czy Twoje dziecko mówi
-item212,5.11597694973399,0.917837393920002,krzesło,Czy Twoje dziecko mówi
-item213,5.81805481677154,0.430746674357415,kuchnia,Czy Twoje dziecko mówi
-item214,5.38435867332375,0.041382928616514,lodówka,Czy Twoje dziecko mówi
-item215,5.53885828543339,0.050165065562225,łazienka,Czy Twoje dziecko mówi
-item216,5.68112109939801,1.28021771622585,łóżko,Czy Twoje dziecko mówi
-item217,3.99621153779218,-0.08060373351507,odkurzacz,Czy Twoje dziecko mówi
-item218,4.48126248157205,1.57307243262679,okno,Czy Twoje dziecko mówi
-item219,5.8765135549827,-0.759256865386402,podłoga,Czy Twoje dziecko mówi
-item220,5.99003524578335,0.372653101170724,pokój,Czy Twoje dziecko mówi
-item221,4.54334110990617,-2.12356525287887,półka regał,Czy Twoje dziecko mówi
-item222,5.05558363896948,0.1368940201459,pralka,Czy Twoje dziecko mówi
-item223,3.94924129213452,-1.39285984686685,prysznic,Czy Twoje dziecko mówi
-item224,5.73332674134089,0.047509677813068,schody,Czy Twoje dziecko mówi
-item225,3.67805613899343,-1.56380928525796,stołek,Czy Twoje dziecko mówi
-item226,5.90018461774569,1.21783794635013,stół,Czy Twoje dziecko mówi
-item227,4.06600585920625,-2.09428061685936,sufit,Czy Twoje dziecko mówi
-item228,5.53379922769509,-0.09658395052903,szafa,Czy Twoje dziecko mówi
-item229,4.87266983190882,-1.83598742794658,szuflada,Czy Twoje dziecko mówi
-item230,5.47514933976087,-0.931474493661421,ściana,Czy Twoje dziecko mówi
-item231,4.49252938978059,0.778441922455318,telewizor,Czy Twoje dziecko mówi
-item232,3.3146042952583,-0.947134980670909,ubikacja ustęp,Czy Twoje dziecko mówi
-item233,4.11778478650876,0.106159628085169,wanna,Czy Twoje dziecko mówi
-item234,4.65483503125409,1.07030843181057,wózek,Czy Twoje dziecko mówi
-item235,3.7328891416757,-0.984479804612667,aparat kamera,Czy Twoje dziecko mówi
-item236,4.39013998032533,1.27108413855085,butelka,Czy Twoje dziecko mówi
-item237,4.01607138958727,-1.11628540549631,czajnik,Czy Twoje dziecko mówi
-item238,4.16995141143687,-1.59459375490083,deska,Czy Twoje dziecko mówi
-item239,5.15891423252202,-0.417094087591993,garnek,Czy Twoje dziecko mówi
-item240,4.69680677278124,-0.886363366052308,gazeta,Czy Twoje dziecko mówi
-item241,3.87842439149165,-0.978018170627906,grzebień,Czy Twoje dziecko mówi
-item242,3.55607711674471,-2.02272509770383,igła,Czy Twoje dziecko mówi
-item243,4.62974751116848,0.914294769858367,klucz,Czy Twoje dziecko mówi
-item244,4.2620036512069,0.935831465609202,koc kołdra,Czy Twoje dziecko mówi
-item245,4.53502649727847,-1.28988359935114,koszyk,Czy Twoje dziecko mówi
-item246,4.86395054270569,1.22815417536289,kubek,Czy Twoje dziecko mówi
-item247,3.6724314666663,0.373655748564995,lampa,Czy Twoje dziecko mówi
-item248,4.43291083668597,-1.10807191905695,lekarstwa tabletki,Czy Twoje dziecko mówi
-item249,5.3878855774249,-0.468013805103988,lustro,Czy Twoje dziecko mówi
-item250,5.55796061564914,1.15678125019844,łyżka,Czy Twoje dziecko mówi
-item251,3.14562248548399,-1.01392011419125,miotła,Czy Twoje dziecko mówi
-item252,4.42534028209906,0.016149034623781,miska,Czy Twoje dziecko mówi
-item253,4.10146955464106,-1.19465689483842,młotek,Czy Twoje dziecko mówi
-item254,4.9073853579077,0.442307593252009,mydło,Czy Twoje dziecko mówi
-item255,3.39256291670381,-2.07256735765508,nici,Czy Twoje dziecko mówi
-item256,4.01650227076491,0.736084346613317,nocnik,Czy Twoje dziecko mówi
-item257,4.68170209205496,-0.577943349813542,nożyczki,Czy Twoje dziecko mówi
-item258,3.7717522549989,0.243546242583344,nóż,Czy Twoje dziecko mówi
-item259,4.86199612951555,-1.61731344364831,obraz,Czy Twoje dziecko mówi
-item260,4.55738499450008,0.625348040552958,okulary,Czy Twoje dziecko mówi
-item261,4.50308212094235,-0.27785359714811,pieniądze,Czy Twoje dziecko mówi
-item262,5.15183055505832,0.447350053478135,poduszka,Czy Twoje dziecko mówi
-item263,6.1563915393497,-1.56883205245505,pudełko,Czy Twoje dziecko mówi
-item264,3.5884768519032,-0.850167412743441,radio,Czy Twoje dziecko mówi
-item265,5.8918627713867,-0.274321047890372,ręcznik,Czy Twoje dziecko mówi
-item266,5.23168957019503,-2.17030718482132,słoik,Czy Twoje dziecko mówi
-item267,4.60571094174148,-0.496742203326518,syrop,Czy Twoje dziecko mówi
-item268,4.32228553734227,-0.029182475888578,szczoteczka do zębów,Czy Twoje dziecko mówi
-item269,4.43888241561489,-0.762903828991904,szczotka,Czy Twoje dziecko mówi
-item270,4.70429910020404,-0.542731922361847,szklanka,Czy Twoje dziecko mówi
-item271,4.71970960899772,-1.56998143419658,szmata ścierka,Czy Twoje dziecko mówi
-item272,4.81791175390622,-2.31312756693522,sznurek,Czy Twoje dziecko mówi
-item273,4.48542737413765,0.495385984855583,śmieci,Czy Twoje dziecko mówi
-item274,5.27228796106478,0.126926993374197,talerz,Czy Twoje dziecko mówi
-item275,3.52330074656456,1.47980561856498,telefon komórka,Czy Twoje dziecko mówi
-item276,4.12191131803299,-1.93375953551041,termometr,Czy Twoje dziecko mówi
-item277,5.08808027690127,-0.561637510820281,torebka,Czy Twoje dziecko mówi
-item278,5.51121581584678,-0.243130823368633,widelec,Czy Twoje dziecko mówi
-item279,3.60627090096753,-1.85243074180111,zapałki,Czy Twoje dziecko mówi
-item280,5.0868292417988,-0.642100777779233,zdjęcie fotografia,Czy Twoje dziecko mówi
-item281,4.11989044596248,0.092160854070879,zegarek,Czy Twoje dziecko mówi
-item282,3.96497390689574,-1.39742275870889,żelazko,Czy Twoje dziecko mówi
-item283,3.72887707310793,-1.06023978002441,bałwan,Czy Twoje dziecko mówi
-item284,3.98910989097436,-0.536355205243472,błoto,Czy Twoje dziecko mówi
-item285,3.96316357758338,0.133131936287828,burza,Czy Twoje dziecko mówi
-item286,4.77663634473556,-0.392545825162705,chmura,Czy Twoje dziecko mówi
-item287,4.30138192812995,1.87542188151542,deszcz,Czy Twoje dziecko mówi
-item288,4.32797642335008,-1.5876604957315,drabina,Czy Twoje dziecko mówi
-item289,4.56712417462748,-0.192946311202057,droga,Czy Twoje dziecko mówi
-item290,5.46417087710277,1.26431174706288,drzewo,Czy Twoje dziecko mówi
-item291,4.01440767738524,-2.56086697459215,gałąź,Czy Twoje dziecko mówi
-item292,4.75741478957074,-0.661523320574645,gwiazda,Czy Twoje dziecko mówi
-item293,3.42543406223646,0.969006757878171,huśtawka,Czy Twoje dziecko mówi
-item294,5.85531245274438,0.152427124326961,kamień,Czy Twoje dziecko mówi
-item295,4.4683681937424,0.087140539532855,kijek patyk,Czy Twoje dziecko mówi
-item296,4.21763889668422,-0.380922721883885,księżyc,Czy Twoje dziecko mówi
-item297,4.92661175502414,1.44722293559552,kwiatek,Czy Twoje dziecko mówi
-item298,5.16465233465969,0.037676840761488,listek,Czy Twoje dziecko mówi
-item299,3.69112033295798,-1.36442322784635,most,Czy Twoje dziecko mówi
-item300,3.43862640965839,-2.33904719940919,mróz,Czy Twoje dziecko mówi
-item301,4.33470445621928,0.259755120302975,niebo,Czy Twoje dziecko mówi
-item302,3.64633156333809,-0.474804131851309,ogień,Czy Twoje dziecko mówi
-item303,5.51822911915937,0.654692146768858,piasek piaskownica,Czy Twoje dziecko mówi
-item304,4.26285990337202,-1.35103436098654,płot,Czy Twoje dziecko mówi
-item305,4.54071268160746,-1.3450047265219,sanki,Czy Twoje dziecko mówi
-item306,5.22597679583392,0.861698566081087,słońce,Czy Twoje dziecko mówi
-item307,4.64203043379989,-0.882938759574271,śnieg,Czy Twoje dziecko mówi
-item308,5.90462851706224,0.617171074172548,trawa,Czy Twoje dziecko mówi
-item309,4.55651738771032,-0.848086669427381,ulica,Czy Twoje dziecko mówi
-item310,5.01070939130415,-0.40193613011229,wiatr,Czy Twoje dziecko mówi
-item311,4.30862374186378,1.95622630009381,woda,Czy Twoje dziecko mówi
-item312,4.51431535769152,-1.26348199424888,ziemia,Czy Twoje dziecko mówi
-item313,3.54590149968045,-1.99894179656885,apteka,Czy Twoje dziecko mówi
-item314,4.11891061567544,2.93519293510791,dom,Czy Twoje dziecko mówi
-item315,2.84158731287497,-1.73326496345738,góry,Czy Twoje dziecko mówi
-item316,4.0086002394664,-1.50836919151033,imieniny urodziny,Czy Twoje dziecko mówi
-item317,3.3886328113444,-0.474151863036315,kościół,Czy Twoje dziecko mówi
-item318,3.3007998766248,0.156173181525869,las,Czy Twoje dziecko mówi
-item319,3.62227036317649,-1.72163330753192,miasto,Czy Twoje dziecko mówi
-item320,3.14995071597493,-1.13499376606287,morze,Czy Twoje dziecko mówi
-item321,3.33374561676871,0.659789026144783,na dwór na pole,Czy Twoje dziecko mówi
-item322,3.98494360996649,-1.10918010925119,park ogród,Czy Twoje dziecko mówi
-item323,3.35779102393284,-2.28223992152361,poczta,Czy Twoje dziecko mówi
-item324,3.25542587345117,-0.769576897686614,podwórko,Czy Twoje dziecko mówi
-item325,3.70873098132428,0.231057726367272,praca,Czy Twoje dziecko mówi
-item326,3.77761991037021,-1.83893052192395,rzeka,Czy Twoje dziecko mówi
-item327,4.87131764356184,1.21892438658417,sklep,Czy Twoje dziecko mówi
-item328,4.15825426343678,0.863409883484773,spacer,Czy Twoje dziecko mówi
-item329,4.04422875265821,0.103874733656313,szkoła przedszkole,Czy Twoje dziecko mówi
-item330,2.65998601859295,-0.961581104772431,zoo,Czy Twoje dziecko mówi
-item331,2.45673221979816,4.41196706616813,babcia,Czy Twoje dziecko mówi
-item332,2.37674945071436,-0.686528008691962,brat,Czy Twoje dziecko mówi
-item333,4.37844184797596,0.296935515776441,chłopiec,Czy Twoje dziecko mówi
-item334,2.8599787624139,2.49565998392124,ciocia,Czy Twoje dziecko mówi
-item335,3.58471842794192,-1.50938914436559,córeczka,Czy Twoje dziecko mówi
-item336,5.31455596409013,0.093065335861351,doktor lekarz,Czy Twoje dziecko mówi
-item337,2.08533240492028,2.5769435580716,dziadek dziadzio,Czy Twoje dziecko mówi
-item338,1.84656038769314,1.92129581478979,dzidzi dzidziuś,Czy Twoje dziecko mówi
-item339,3.20654567447172,1.86525212455521,dzieci,Czy Twoje dziecko mówi
-item340,4.21537116880529,0.677397301138075,dziewczynka,Czy Twoje dziecko mówi
-item341,4.04821545650718,-2.07618992782269,fryzjer,Czy Twoje dziecko mówi
-item342,4.2947544476394,-1.20588952509478,goście,Czy Twoje dziecko mówi
-item343,2.13440501753978,0.131912199192953,imię zwierzątka,Czy Twoje dziecko mówi
-item344,4.48887010763202,-1.33711308283869,kolega koleżanka,Czy Twoje dziecko mówi
-item345,4.02341724791058,-2.1916592854638,krasnoludek,Czy Twoje dziecko mówi
-item346,4.25344528423066,-1.33321028488282,król królewna,Czy Twoje dziecko mówi
-item347,3.41537887458111,-1.74355124248287,ksiądz,Czy Twoje dziecko mówi
-item348,4.4393946562971,-1.16166491362176,ludzie,Czy Twoje dziecko mówi
-item349,1.21485427714695,3.70008319255559,mama mamusia,Czy Twoje dziecko mówi
-item350,3.19668778869141,2.51677671730889,pan,Czy Twoje dziecko mówi
-item351,3.43428443313442,1.99893328263737,pani,Czy Twoje dziecko mówi
-item352,4.22973172060913,-1.44409528122617,policjant,Czy Twoje dziecko mówi
-item353,2.80947962497562,-0.877149768733592,siostra,Czy Twoje dziecko mówi
-item354,3.66675202468882,-1.15802079096017,synek,Czy Twoje dziecko mówi
-item355,1.41476161419384,3.57589978463702,tata tatuś,Czy Twoje dziecko mówi
-item356,2.33504698879621,1.5454036086787,własne imię,Czy Twoje dziecko mówi
-item357,3.06517017569379,1.08599027574489,wujek,Czy Twoje dziecko mówi
-item358,2.09078446148401,1.93473866120572,cześć,Czy Twoje dziecko mówi
-item359,3.72083890878191,0.498699587418552,dzień dobry,Czy Twoje dziecko mówi
-item360,3.37439896663492,0.342696045402409,do widzenia,Czy Twoje dziecko mówi
-item361,3.69721406549373,0.011914555185596,dobranoc,Czy Twoje dziecko mówi
-item362,3.82497280973113,1.52181136586606,dziękuję,Czy Twoje dziecko mówi
-item363,3.76952850302315,1.33968894219705,proszę,Czy Twoje dziecko mówi
-item364,4.27964454839401,0.469063085504534,przepraszam,Czy Twoje dziecko mówi
-item365,1.48230133139065,1.34693262921587,halo,Czy Twoje dziecko mówi
-item366,1.52229241024244,3.84518556925825,pa pa ,Czy Twoje dziecko mówi
-item367,2.02631510388727,3.21806758967314,tak,Czy Twoje dziecko mówi
-item368,1.61467307480406,3.4037152461555,nie,Czy Twoje dziecko mówi
-item369,4.4175276188752,-0.243905948041326,śniadanie,Czy Twoje dziecko mówi
-item370,4.48825502642421,0.339667814312223,obiad,Czy Twoje dziecko mówi
-item371,4.3830255633827,-0.714398681174667,kolacja,Czy Twoje dziecko mówi
-item372,2.29261704307047,2.68598503608634,siusiu siku sisi,Czy Twoje dziecko mówi
-item373,2.72095864489492,1.85099938818426,kupka,Czy Twoje dziecko mówi
-item374,1.57474316481998,0.474741757293684,kosi kosi łapci,Czy Twoje dziecko mówi
-item375,2.49886741756669,-0.167512412395661,idzie rak nieborak,Czy Twoje dziecko mówi
-item376,1.7346133039097,-0.698305726316943,sroczka kaszkę warzyła,Czy Twoje dziecko mówi
-item377,0.63712132659387,1.53724139538549,be,Czy Twoje dziecko mówi
-item378,4.03016656594882,-1.23074714414019,biały,Czy Twoje dziecko mówi
-item379,4.29169678360483,0.717628219492417,brudny,Czy Twoje dziecko mówi
-item380,4.09620223699928,-0.339577460285012,brzydki,Czy Twoje dziecko mówi
-item381,1.05564938715895,-0.087394411453255,cacy cacany,Czy Twoje dziecko mówi
-item382,5.57978599981654,0.271629053251373,chory,Czy Twoje dziecko mówi
-item383,3.72803001781075,0.335647499978334,ciepły,Czy Twoje dziecko mówi
-item384,4.70420263911428,-0.806308936980746,ciężki,Czy Twoje dziecko mówi
-item385,4.84419272976346,-1.77409196880913,czarny,Czy Twoje dziecko mówi
-item386,4.29466291118114,-1.42143795021124,czerwony,Czy Twoje dziecko mówi
-item387,5.17127271380513,0.026317468728568,czysty,Czy Twoje dziecko mówi
-item388,4.00954895711604,0.418609896090162,dobry,Czy Twoje dziecko mówi
-item389,4.2728669302271,1.17741901943694,duży,Czy Twoje dziecko mówi
-item390,4.82761316676685,-0.401270303972072,głodny,Czy Twoje dziecko mówi
-item391,3.35202133117663,-1.45434884272608,głupi,Czy Twoje dziecko mówi
-item393,4.13645335734009,-0.590209532839311,kochany,Czy Twoje dziecko mówi
-item394,4.48619337609596,-0.089294309319324,ładny,Czy Twoje dziecko mówi
-item395,4.35876532726501,0.742554669317351,mały,Czy Twoje dziecko mówi
-item396,4.35738133223045,-2.19204334393046,mądry,Czy Twoje dziecko mówi
-item397,4.6802546152372,-0.132881479524677,mokry,Czy Twoje dziecko mówi
-item398,4.42036197897981,-0.259074168495517, nie grzeczny,Czy Twoje dziecko mówi
-item399,4.40103351378431,-1.05996025690371,nowy,Czy Twoje dziecko mówi
-item400,4.62905062612088,-1.61009641869834,otwarty,Czy Twoje dziecko mówi
-item401,4.09112430622234,-1.52410077826909,piękny śliczny,Czy Twoje dziecko mówi
-item402,3.4186998446416,-0.403832697950302,pyszny,Czy Twoje dziecko mówi
-item403,3.27949369140517,-0.396008204969395,śpiący,Czy Twoje dziecko mówi
-item404,4.73928682595149,-0.675664206206732,umyty,Czy Twoje dziecko mówi
-item405,4.8152894914941,-1.26287993542603,zamknięty,Czy Twoje dziecko mówi
-item406,5.75416269515672,-1.12396521110862,zdrowy,Czy Twoje dziecko mówi
-item407,4.21697518928633,-1.13237865909683,zepsuty,Czy Twoje dziecko mówi
-item408,3.814776447238,0.356006392836455,zimny,Czy Twoje dziecko mówi
-item409,4.84263734483848,-1.17877631896237,zmęczony,Czy Twoje dziecko mówi
-item410,3.36197187142903,-0.278789522473532,boso na bosaka,Czy Twoje dziecko mówi
-item411,3.40275675858086,-0.374106672875274,brzydko,Czy Twoje dziecko mówi
-item412,2.63427388338166,1.4231880915538,cicho,Czy Twoje dziecko mówi
-item413,5.31985894082286,0.905617661585033,ciemno,Czy Twoje dziecko mówi
-item414,4.51228771851777,0.477986915241562,ciepło,Czy Twoje dziecko mówi
-item415,3.86694682861182,0.507122914531065,dobrze,Czy Twoje dziecko mówi
-item416,5.16236936726142,-0.452120072467262,głośno,Czy Twoje dziecko mówi
-item418,4.52543853872486,-0.330176927387453,ładnie,Czy Twoje dziecko mówi
-item419,4.64972314426082,-1.01881055943154,mocno,Czy Twoje dziecko mówi
-item420,4.02439707659751,0.218090071784516,mokro,Czy Twoje dziecko mówi
-item421,4.80756178523898,-0.367387893157547,prędko szybko,Czy Twoje dziecko mówi
-item422,3.68021637372658,0.86307106263479,zimno,Czy Twoje dziecko mówi
-item423,3.57160630388861,0.41446258727418,bać się,Czy Twoje dziecko mówi
-item424,5.45989169682233,1.34147490083676,bawić się,Czy Twoje dziecko mówi
-item425,3.05570777086581,-0.128247528322277,bić,Czy Twoje dziecko mówi
-item426,5.77545540165528,0.269796784376949,biec biegać,Czy Twoje dziecko mówi
-item427,3.29383315648934,0.594273255659256,boleć,Czy Twoje dziecko mówi
-item428,5.42568131517071,-0.409941890558193,budować,Czy Twoje dziecko mówi
-item429,3.04863373221261,-0.017371828127395,być  jest ,Czy Twoje dziecko mówi
-item430,4.08246023936735,-0.113946774727708,całować,Czy Twoje dziecko mówi
-item431,3.3343754499887,0.189263688004994,chcieć,Czy Twoje dziecko mówi
-item432,3.7104534098885,1.03926610895408,chodzić  chodź ,Czy Twoje dziecko mówi
-item433,3.41020684013962,-1.72791242610884,ciąć,Czy Twoje dziecko mówi
-item434,4.76655708400019,-1.12379758931582,cieszyć się,Czy Twoje dziecko mówi
-item435,4.93386647942281,-0.586709044230999,czekać,Czy Twoje dziecko mówi
-item436,4.61266233779689,-0.282772090127865,czesać,Czy Twoje dziecko mówi
-item437,4.57514612766049,-1.59378470315694,czyścić,Czy Twoje dziecko mówi
-item438,4.74729404660244,0.607568175080387,czytać,Czy Twoje dziecko mówi
-item439,2.08170707610367,1.42353295579918,dać,Czy Twoje dziecko mówi
-item440,4.55515217659803,-0.424933727685594,dmuchać,Czy Twoje dziecko mówi
-item441,5.1826176855485,-1.22131661776693,dostać,Czy Twoje dziecko mówi
-item442,5.30391576530077,-1.70441336209153,drapać,Czy Twoje dziecko mówi
-item443,4.41877286622377,0.617554299393074,dzwonić,Czy Twoje dziecko mówi
-item444,4.19929541396329,-0.826797609553851,gonić,Czy Twoje dziecko mówi
-item445,5.71463049750884,-0.446381080001825,gotować,Czy Twoje dziecko mówi
-item446,4.66293978166755,0.01400184170221,grać,Czy Twoje dziecko mówi
-item447,5.17772718809402,-1.07101298342728,gryźć,Czy Twoje dziecko mówi
-item448,3.29958160953119,0.864379651717812,huśtać bujać się,Czy Twoje dziecko mówi
-item449,3.19391042363779,1.43095897616213,iść pójść,Czy Twoje dziecko mówi
-item450,3.99021880743085,0.901716685469006,jechać jeździć,Czy Twoje dziecko mówi
-item451,2.78975250292023,1.80673229431208,jeść,Czy Twoje dziecko mówi
-item452,3.97904687187879,1.23271459964587,kąpać się,Czy Twoje dziecko mówi
-item453,4.48182901765037,-0.640010056697782,kłaść położyć,Czy Twoje dziecko mówi
-item454,4.38784649540436,0.356823408030941,kochać,Czy Twoje dziecko mówi
-item455,4.51515370619022,-0.669835106235948,kopać,Czy Twoje dziecko mówi
-item456,5.74244682771086,-0.919405993809089,krzyczeć wołać,Czy Twoje dziecko mówi
-item457,5.96649418343249,0.214954999565448,kupić,Czy Twoje dziecko mówi
-item458,3.40427119636664,-1.84876807947785,lać,Czy Twoje dziecko mówi
-item459,4.56602539529957,-1.206029260096,lecieć latać,Czy Twoje dziecko mówi
-item460,5.63564137903958,-0.29075419932307,leżeć,Czy Twoje dziecko mówi
-item461,5.31255094227945,-0.492523021400935,lubić,Czy Twoje dziecko mówi
-item462,4.68326836994383,0.150524961214896,malować,Czy Twoje dziecko mówi
-item463,2.08863544179706,0.797876075876907,mieć  ma ,Czy Twoje dziecko mówi
-item464,5.50731236908928,-2.19478403348829,mieszkać,Czy Twoje dziecko mówi
-item465,4.1147529869201,-1.13398305685675,móc  może ,Czy Twoje dziecko mówi
-item466,5.68169396163354,-0.949500947825196,mówić powiedzieć,Czy Twoje dziecko mówi
-item467,4.82975096959884,-1.42489784586172,musieć  musi ,Czy Twoje dziecko mówi
-item468,3.42605051270859,1.27303386585456,myć  się ,Czy Twoje dziecko mówi
-item469,5.18721165274405,-2.86014388055752,myśleć,Czy Twoje dziecko mówi
-item470,4.83537994343099,-1.63251223382214,naprawiać reperować,Czy Twoje dziecko mówi
-item471,4.7860210851648,-1.5154193587335,nazywać się,Czy Twoje dziecko mówi
-item472,5.34722320421371,-1.59772625672311,nieść nosić,Czy Twoje dziecko mówi
-item473,5.8103673155716,-0.804215684054417,obudzić  się ,Czy Twoje dziecko mówi
-item474,5.84349120715277,-0.369965025206509,oglądać obejrzeć,Czy Twoje dziecko mówi
-item475,5.21438066472144,-2.03818918811587,opowiadać,Czy Twoje dziecko mówi
-item476,5.37938398431075,-0.521741753851766,otworzyć,Czy Twoje dziecko mówi
-item477,3.59263317436655,-1.31748068521192,palić  się ,Czy Twoje dziecko mówi
-item478,4.31147785496637,-0.515888677603169,patrzeć  patrz ,Czy Twoje dziecko mówi
-item479,2.66811994319651,2.02845931850353,pić,Czy Twoje dziecko mówi
-item480,3.8930041940799,0.313627419811686,pisać,Czy Twoje dziecko mówi
-item481,4.09587459237122,-2.02274000858087,pluć,Czy Twoje dziecko mówi
-item482,4.9946965870647,0.505378102431407,płakać,Czy Twoje dziecko mówi
-item483,5.18254895658863,-2.20840879403371,podobać się,Czy Twoje dziecko mówi
-item484,5.85958262616096,-1.33701042956217,pokazać,Czy Twoje dziecko mówi
-item485,5.79751039405517,-1.19118454134346,pomóc,Czy Twoje dziecko mówi
-item486,4.91615460504445,-3.09374194973606,pożyczyć,Czy Twoje dziecko mówi
-item487,5.19822181516358,-1.17653159027937,pracować,Czy Twoje dziecko mówi
-item488,4.5091267421827,-0.887677571703359,prać,Czy Twoje dziecko mówi
-item489,4.73214091677564,-1.94415140765711,prasować,Czy Twoje dziecko mówi
-item490,4.58405213925833,-0.484423851752489,prosić,Czy Twoje dziecko mówi
-item491,5.53418574432667,-1.2823648030091,przyjść,Czy Twoje dziecko mówi
-item492,5.41192449361201,-1.25065499787119,przykryć,Czy Twoje dziecko mówi
-item493,5.9262007715579,-1.31685235241377,przynieść,Czy Twoje dziecko mówi
-item494,4.3625003891497,-1.49823287243752,puścić,Czy Twoje dziecko mówi
-item495,5.28008145715461,-0.620870907228719,robić,Czy Twoje dziecko mówi
-item496,5.90968692660008,-1.77830274586162,rozmawiać,Czy Twoje dziecko mówi
-item497,4.67348964253067,0.160603439552395,rysować,Czy Twoje dziecko mówi
-item498,4.86984636110505,-0.724534680436165,rzucać,Czy Twoje dziecko mówi
-item499,6.17924677522229,-1.08634846140509,schować,Czy Twoje dziecko mówi
-item500,4.70284746884808,0.156524369824762,siedzieć,Czy Twoje dziecko mówi
-item501,4.20784954112232,0.337821671932025,skakać,Czy Twoje dziecko mówi
-item502,5.43988732588061,-2.38667479004298,skończyć,Czy Twoje dziecko mówi
-item503,6.11471456214759,-1.4955697167783,słyszeć słuchać,Czy Twoje dziecko mówi
-item504,3.02101757198439,1.96955566630642,spać,Czy Twoje dziecko mówi
-item505,5.88790488471263,0.005058812214746,sprzątać,Czy Twoje dziecko mówi
-item506,4.64660435283872,-0.51614871419722,stać,Czy Twoje dziecko mówi
-item507,3.93764138010521,-0.563093475633016,stukać pukać,Czy Twoje dziecko mówi
-item508,6.17690405681206,-0.647647609536482,szukać,Czy Twoje dziecko mówi
-item509,4.16361005199523,-2.63915126600376,szyć,Czy Twoje dziecko mówi
-item510,5.34419931391653,-0.621186538326175,śmiać się,Czy Twoje dziecko mówi
-item511,4.2161192987642,0.171369511895651,śpiewać,Czy Twoje dziecko mówi
-item512,4.0281546185307,0.774906642450744,tańczyć,Czy Twoje dziecko mówi
-item513,5.86649332256099,-1.17716695638084,trzymać,Czy Twoje dziecko mówi
-item514,5.7068282098277,-0.059807705912378,ubrać  się ,Czy Twoje dziecko mówi
-item515,5.79929277662594,-1.03277728818607,uciekać,Czy Twoje dziecko mówi
-item516,5.00262007934447,-1.95163446010247,uczyć się,Czy Twoje dziecko mówi
-item517,5.53329811094308,-1.71286154813362,umieć,Czy Twoje dziecko mówi
-item518,3.41004296712625,-0.394974330815415,upaść spaść,Czy Twoje dziecko mówi
-item519,4.9296265831372,-0.391257601853637,usiąść siadać,Czy Twoje dziecko mówi
-item520,4.86540721855613,-1.41696802853972,uściskać ukochać,Czy Twoje dziecko mówi
-item521,5.53892896176006,-2.89558387649404,wiązać,Czy Twoje dziecko mówi
-item522,5.33986751343096,-1.04547244131227,widzieć zobaczyć,Czy Twoje dziecko mówi
-item523,5.50930568845558,-2.42116646871324,wiedzieć,Czy Twoje dziecko mówi
-item524,5.83192940479666,-1.47907921913605,włożyć założyć,Czy Twoje dziecko mówi
-item525,5.06517279727709,-0.789477143667466,wstawać,Czy Twoje dziecko mówi
-item526,5.73259994368208,-0.866076242200739,wyrzucić,Czy Twoje dziecko mówi
-item527,5.76507645151082,-1.28427762750444,wytrzeć,Czy Twoje dziecko mówi
-item528,5.24879557240596,-1.22909324613355,zamiatać,Czy Twoje dziecko mówi
-item529,5.59421409872818,-0.457537119875893,zamknąć,Czy Twoje dziecko mówi
-item530,5.53365161952524,-1.68703914412726,zapiąć,Czy Twoje dziecko mówi
-item531,5.16735126606332,-0.879689081710848,zaświecić zapalić,Czy Twoje dziecko mówi
-item532,5.84183627167303,-1.25289647550425,zdjąć ściągnąć,Czy Twoje dziecko mówi
-item533,5.28293181522481,-0.704744676938634,zepsuć,Czy Twoje dziecko mówi
-item534,5.41493619512972,-1.54643678684074,zgubić,Czy Twoje dziecko mówi
-item535,5.77832098284508,-2.57861534242898,złamać,Czy Twoje dziecko mówi
-item536,6.59470531486282,-2.0623773775202,złapać,Czy Twoje dziecko mówi
-item537,6.16222208881549,-1.33650345696511,zmęczyć się,Czy Twoje dziecko mówi
-item538,5.01052809219646,-2.60151252517076,znać,Czy Twoje dziecko mówi
-item539,6.71143965823071,-2.2851149435442,znaleźć,Czy Twoje dziecko mówi
-item540,5.34957869252163,-1.86933159268436,zostać,Czy Twoje dziecko mówi
-item541,3.08390056046082,-0.069284217788466, nie  da się,Czy Twoje dziecko mówi
-item542,1.88514922422711,1.96861776354637,nie ma ,Czy Twoje dziecko mówi
-item543,3.75071140206213,-0.035200785964216, nie  można,Czy Twoje dziecko mówi
-item544,3.86000981924363,-1.31971622832019, nie  trzeba,Czy Twoje dziecko mówi
-item545,3.00069530673904,0.839476879521574, nie  wolno,Czy Twoje dziecko mówi
-item546,2.32182540460115,3.3307195703388,tu,Czy Twoje dziecko mówi
-item547,2.10112788689191,2.19644545703215,tam,Czy Twoje dziecko mówi
-item548,2.54589918453726,-1.49583468482598,tędy,Czy Twoje dziecko mówi
-item549,3.55822385076303,-3.20254007383648,stąd,Czy Twoje dziecko mówi
-item550,5.26270143394889,0.190543711953318,daleko,Czy Twoje dziecko mówi
-item551,4.99579125609004,-1.22876744854995,blisko,Czy Twoje dziecko mówi
-item552,4.13675899929735,0.435634095780853,wysoko,Czy Twoje dziecko mówi
-item553,3.82437078858112,-1.11427764118141,nisko,Czy Twoje dziecko mówi
-item554,3.94147618723834,0.466210447743276,na górę na górze,Czy Twoje dziecko mówi
-item555,3.92134229954218,-0.061978089532521,na dół na dole,Czy Twoje dziecko mówi
-item556,4.21383814191793,-1.76442681082143,z tyłu do tyłu,Czy Twoje dziecko mówi
-item557,4.32594443480895,-2.05782468194119,z przodu do przodu,Czy Twoje dziecko mówi
-item558,4.2039750291867,-2.06201599479768,w środku,Czy Twoje dziecko mówi
-item559,2.90257633768416,-1.69281470466508,gdzieś,Czy Twoje dziecko mówi
-item560,3.1576010930853,-1.90980332855641,nigdzie,Czy Twoje dziecko mówi
-item561,3.97988504381503,-2.90055337634268,wszędzie,Czy Twoje dziecko mówi
-item562,2.24253047570465,0.679780631145206,już już nie,Czy Twoje dziecko mówi
-item563,3.16487860783521,-0.058519344780676,jeszcze jeszcze nie,Czy Twoje dziecko mówi
-item564,3.48629480603137,0.017666073296681,teraz,Czy Twoje dziecko mówi
-item565,3.15864765401496,-0.886148926024031,zaraz,Czy Twoje dziecko mówi
-item566,3.45137790227929,-1.09159603528459,potem później,Czy Twoje dziecko mówi
-item567,4.1106406417328,-2.56618683744453,znowu znów,Czy Twoje dziecko mówi
-item568,4.11731025981056,-3.25322815216069,kiedyś,Czy Twoje dziecko mówi
-item569,3.40708031453775,-2.63519153768231,nigdy,Czy Twoje dziecko mówi
-item570,4.19729527530508,-3.12813168265165,zawsze,Czy Twoje dziecko mówi
-item571,3.93271298222589,-3.34072896942367,czasem,Czy Twoje dziecko mówi
-item572,3.97800736409541,-0.41051198898356,dzisiaj dziś,Czy Twoje dziecko mówi
-item573,3.71453994760591,-0.59083236299397,jutro,Czy Twoje dziecko mówi
-item574,4.09068060739974,-1.7823237818834,wczoraj,Czy Twoje dziecko mówi
-item575,3.82338272262067,-0.775585128033938,rano,Czy Twoje dziecko mówi
-item576,4.00451220245436,-1.87763468572541,wieczorem,Czy Twoje dziecko mówi
-item577,3.93276062033656,-0.270408731191686,noc w nocy,Czy Twoje dziecko mówi
-item578,4.05101318710924,-0.783877841901274,dzień,Czy Twoje dziecko mówi
-item579,3.78754282024472,-2.1064274438187,godzina,Czy Twoje dziecko mówi
-item580,4.65476757521312,2.00763865732202,dużo,Czy Twoje dziecko mówi
-item581,3.96750621952953,1.0766554331324,mało,Czy Twoje dziecko mówi
-item582,4.00774931256757,-1.3366320716577,trochę troszkę,Czy Twoje dziecko mówi
-item583,2.5316810471164,-1.10064746332014,tyle,Czy Twoje dziecko mówi
-item584,4.49674760222469,-2.17244927104697,więcej,Czy Twoje dziecko mówi
-item585,3.10479246543203,0.405136494088475,jeszcze,Czy Twoje dziecko mówi
-item586,4.64220106056981,-1.94014440382921,wszystko wszyscy,Czy Twoje dziecko mówi
-item587,2.97481643481967,-1.01578418591871,inny,Czy Twoje dziecko mówi
-item588,3.10097394746448,-0.746597569175617,drugi,Czy Twoje dziecko mówi
-item589,3.94583777056493,-1.30040234723223,cały,Czy Twoje dziecko mówi
-item590,4.48531858036306,-1.330881611216,bardzo,Czy Twoje dziecko mówi
-item591,4.76546359899615,-2.34461645819543,tylko,Czy Twoje dziecko mówi
-item592,2.69729944951679,1.00904699922499,sam sama,Czy Twoje dziecko mówi
-item593,4.36688959156583,-1.36851174497387,razem,Czy Twoje dziecko mówi
-item594,2.70871448115984,-0.962594285827408,też,Czy Twoje dziecko mówi
-item595,2.45127802892123,-1.43427736609229,dosyć dość,Czy Twoje dziecko mówi
-item596,3.38182545831285,-1.26121530343181,za  np  za dużo ,Czy Twoje dziecko mówi
-item597,4.20855586154414,-3.30576530975393,każdy,Czy Twoje dziecko mówi
-item598,3.73158699271382,-4.33521340958653,niektóry,Czy Twoje dziecko mówi
-item599,3.93034136190098,-3.63672421434391,żaden,Czy Twoje dziecko mówi
-item600,2.12414162298577,2.48331262361921,ja  mi  mnie ,Czy Twoje dziecko mówi
-item601,2.39124093540468,0.990615735687325,ty  ci  cię ,Czy Twoje dziecko mówi
-item602,2.30054959039331,-0.276657345618966,on  mu  go ,Czy Twoje dziecko mówi
-item603,2.7304824247366,-0.796304339540789,ona  jej  ją ,Czy Twoje dziecko mówi
-item604,2.92602725308987,-0.898556991294082,my  nam  nas ,Czy Twoje dziecko mówi
-item605,2.9369876810458,-2.01534584887471,wy  wam  was ,Czy Twoje dziecko mówi
-item606,2.87652708193284,-2.03848046131396,oni one  im  ich je ,Czy Twoje dziecko mówi
-item607,2.72356573515742,-2.5305033697548,się,Czy Twoje dziecko mówi
-item608,2.97722732278531,-3.16452308720936,sobie,Czy Twoje dziecko mówi
-item609,2.78215386822413,1.12594494460027,mój,Czy Twoje dziecko mówi
-item610,3.32312756037512,-0.704452054848642,twój,Czy Twoje dziecko mówi
-item611,2.89225570625681,-2.11744646496608,jego,Czy Twoje dziecko mówi
-item612,2.77168911468943,-2.06891824038173,jej,Czy Twoje dziecko mówi
-item613,3.29926888052457,-1.60129475446621,nasz,Czy Twoje dziecko mówi
-item614,3.32332096104609,-3.12330433420269,wasz,Czy Twoje dziecko mówi
-item615,3.23484155205021,-3.25298229755413,ich,Czy Twoje dziecko mówi
-item616,3.13524102745548,-3.12590760192462,swój,Czy Twoje dziecko mówi
-item617,1.97029329381214,2.41096272693798,to,Czy Twoje dziecko mówi
-item618,2.7563490462606,-0.819236618496971,coś,Czy Twoje dziecko mówi
-item619,3.12446764356246,-1.53742436908188,ktoś,Czy Twoje dziecko mówi
-item620,2.45853540990221,0.629046061388881,nic,Czy Twoje dziecko mówi
-item621,3.65154046990632,-2.25020506641213,nikt,Czy Twoje dziecko mówi
-item622,2.00367066499904,0.002881364099064,ten,Czy Twoje dziecko mówi
-item623,2.97752389555514,-2.07086218429843,tamten,Czy Twoje dziecko mówi
-item624,2.91826592257141,-1.00204651271898,taki,Czy Twoje dziecko mówi
-item625,3.73831910323831,-2.96384901655936,jakiś,Czy Twoje dziecko mówi
-item626,2.61420239000496,1.51133166266881,co to  co to jest ,Czy Twoje dziecko mówi
-item627,2.16741751754379,0.942324677794988,co ,Czy Twoje dziecko mówi
-item628,4.42939879530899,-0.229289195828978,co robi ,Czy Twoje dziecko mówi
-item629,3.16459714111685,0.180270180066289,kto ,Czy Twoje dziecko mówi
-item630,3.63626290816973,-2.46898266696096,czyj ,Czy Twoje dziecko mówi
-item631,3.54615768935942,0.254496682914037,gdzie ,Czy Twoje dziecko mówi
-item632,4.33372771524065,-1.71633693298433,kiedy ,Czy Twoje dziecko mówi
-item633,3.39286874751803,-1.11535865388474,jak ,Czy Twoje dziecko mówi
-item634,4.16304827879897,-1.13513109067046,dlaczego czemu ,Czy Twoje dziecko mówi
-item635,3.34321783385807,-0.969832150894513,po co na co ,Czy Twoje dziecko mówi
-item636,3.87564289829871,-1.22956766104818,jaki ,Czy Twoje dziecko mówi
-item637,4.07571766914641,-2.52030052338867,który ,Czy Twoje dziecko mówi
-item638,3.46834288441519,-1.45311271629135,ile ,Czy Twoje dziecko mówi
-item639,3.05388423303913,-1.36882712836908,chyba,Czy Twoje dziecko mówi
-item640,3.23468169760692,-1.34834246531652,może,Czy Twoje dziecko mówi
-item641,3.67008668305598,-2.88122737743377,na pewno,Czy Twoje dziecko mówi
-item642,3.51131603274844,-2.3164059352171,naprawdę,Czy Twoje dziecko mówi
-item643,3.25123499380902,-2.95220726961409,pewnie,Czy Twoje dziecko mówi
-item644,3.58381256932076,-3.28207540539954,przecież,Czy Twoje dziecko mówi
-item645,3.08088244432375,-3.22411897394949,w ogóle,Czy Twoje dziecko mówi
-item646,3.36652938559125,-2.68012227671068,właśnie,Czy Twoje dziecko mówi
-item647,3.33180936436893,-0.508419562102019,bez,Czy Twoje dziecko mówi
-item648,3.7795557475227,0.287610727917607,dla,Czy Twoje dziecko mówi
-item649,3.48991904296224,0.863051122850386,do,Czy Twoje dziecko mówi
-item650,3.4516953540871,0.345507087299581,na,Czy Twoje dziecko mówi
-item651,3.62341746799104,-1.54067998530869,koło obok,Czy Twoje dziecko mówi
-item653,3.90813888607106,-0.405049008169332,od,Czy Twoje dziecko mówi
-item654,3.45302002684564,-1.02803070595076,po,Czy Twoje dziecko mówi
-item655,3.8954633198572,-1.04673685181349,pod,Czy Twoje dziecko mówi
-item656,4.14503705468109,-2.72687998908128,przed,Czy Twoje dziecko mówi
-item657,2.96829569427949,0.047270261789659,u,Czy Twoje dziecko mówi
-item658,3.79524255036758,-0.27694537201806,w,Czy Twoje dziecko mówi
-item659,3.40339975767652,-1.34070085598879,za,Czy Twoje dziecko mówi
-item660,3.38587080002141,0.140137699149503,z  np  tatusiem ,Czy Twoje dziecko mówi
-item661,3.50542988624035,-1.15249730956484,z  np  łazienki ,Czy Twoje dziecko mówi
-item662,1.33766224937188,0.046276606100065,a,Czy Twoje dziecko mówi
-item663,3.35428733748693,-2.15925051321118,albo,Czy Twoje dziecko mówi
-item664,2.91139529750237,-1.32266007774134,ale,Czy Twoje dziecko mówi
-item665,2.46517042069038,-0.841428547431307,bo,Czy Twoje dziecko mówi
-item666,2.02541433612221,0.022807458631044,i,Czy Twoje dziecko mówi
-item667,3.01966067883373,-1.7032215457634,jak    to ,Czy Twoje dziecko mówi
-item668,3.72160552003402,-2.09191448828567,tylko,Czy Twoje dziecko mówi
-item669,3.19067065565046,-2.16355953279261,że,Czy Twoje dziecko mówi
-item670,3.7737213144783,-3.15319725013097,żeby,Czy Twoje dziecko mówi
+,a1,d,item,question,group
+item1,1.23138524388075,0.405483351886401,gę gę,Czy Twoje dziecko mówi,mowa
+item2,1.35386870628754,2.89042878862175,hau hau,Czy Twoje dziecko mówi,mowa
+item3,1.22826577610391,2.12653266696281,ko ko ko,Czy Twoje dziecko mówi,mowa
+item4,1.52956729905576,1.49589133582856,kwa kwa,Czy Twoje dziecko mówi,mowa
+item5,1.39348290633965,2.77438117056279,miau,Czy Twoje dziecko mówi,mowa
+item6,1.29965654481926,1.64131548456154,mee bee,Czy Twoje dziecko mówi,mowa
+item7,1.38365125894468,2.47799291781542,muu  krowa ,Czy Twoje dziecko mówi,mowa
+item8,1.1271224958264,0.715550049560748,pi pi pi ćwir ćwir,Czy Twoje dziecko mówi,mowa
+item9,0.755455622303629,1.38622108095382,bam bum bęc,Czy Twoje dziecko mówi,mowa
+item10,0.818206239721638,1.5820247452698,brrum brrum,Czy Twoje dziecko mówi,mowa
+item11,1.58479926902752,0.771763380955884,tik tak,Czy Twoje dziecko mówi,mowa
+item12,1.13658142225624,0.840238155627176,tralala lalala,Czy Twoje dziecko mówi,mowa
+item13,2.43162168388127,-0.218870614469224,baran,Czy Twoje dziecko mówi,mowa
+item14,3.62882952331884,0.137726839132282,biedronka,Czy Twoje dziecko mówi,mowa
+item15,2.9432330867363,-0.31341206017346,bocian,Czy Twoje dziecko mówi,mowa
+item16,2.55893505902479,-0.766382087602793,foka,Czy Twoje dziecko mówi,mowa
+item17,2.12431741761044,-0.639900219432973,gęś,Czy Twoje dziecko mówi,mowa
+item18,2.58735070485951,-0.778710353942218,gołąb,Czy Twoje dziecko mówi,mowa
+item19,2.90281368342521,-0.541206770751403,jeż,Czy Twoje dziecko mówi,mowa
+item20,2.6178385869125,1.15883479687528,kaczka,Czy Twoje dziecko mówi,mowa
+item21,2.35910614449616,0.078019125261643,kogut,Czy Twoje dziecko mówi,mowa
+item22,2.77054561737004,1.73417703375554,koń,Czy Twoje dziecko mówi,mowa
+item23,2.58090361223077,3.09827816371303,kot,Czy Twoje dziecko mówi,mowa
+item24,2.69283142324546,-0.130413574008895,koza,Czy Twoje dziecko mówi,mowa
+item25,2.76151284605267,1.74997289859053,krowa,Czy Twoje dziecko mówi,mowa
+item26,3.1766913505227,0.059320439865719,królik,Czy Twoje dziecko mówi,mowa
+item27,2.67307351121665,1.81244678386503,kura,Czy Twoje dziecko mówi,mowa
+item28,2.12134905640328,-1.28442100368917,kurczątko,Czy Twoje dziecko mówi,mowa
+item29,2.84950242409146,0.483737603248925,lew,Czy Twoje dziecko mówi,mowa
+item30,2.72763115279214,-0.223388460917203,lis,Czy Twoje dziecko mówi,mowa
+item31,3.08102523160744,0.402590355469381,małpa,Czy Twoje dziecko mówi,mowa
+item32,2.42472631909309,1.2147326750557,miś niedźwiedź,Czy Twoje dziecko mówi,mowa
+item33,3.75382968533949,0.069007855709273,motylek,Czy Twoje dziecko mówi,mowa
+item34,3.62990779019329,-0.835985058644601,mrówka,Czy Twoje dziecko mówi,mowa
+item35,3.10123410764956,1.26795964165362,mucha,Czy Twoje dziecko mówi,mowa
+item36,3.42271540060668,0.621547857592157,myszka,Czy Twoje dziecko mówi,mowa
+item37,3.44752937795183,-0.38170467616236,pająk,Czy Twoje dziecko mówi,mowa
+item38,2.47865502723727,2.5186180675481,pies,Czy Twoje dziecko mówi,mowa
+item39,3.04744864182047,-1.08433278000211,pingwin,Czy Twoje dziecko mówi,mowa
+item40,3.17798323641325,0.89328768909845,ptaszek,Czy Twoje dziecko mówi,mowa
+item41,3.67074418802879,-0.279127276414981,robak,Czy Twoje dziecko mówi,mowa
+item42,3.49095219457203,1.49935771340304,ryba,Czy Twoje dziecko mówi,mowa
+item43,3.25618446391709,0.518610605376144,słoń,Czy Twoje dziecko mówi,mowa
+item44,2.61705103136815,-0.317884017628774,sowa,Czy Twoje dziecko mówi,mowa
+item45,3.70158157111798,-0.267809268928413,ślimak,Czy Twoje dziecko mówi,mowa
+item46,3.02503214959037,0.532753352490288,świnka,Czy Twoje dziecko mówi,mowa
+item47,2.96606079146206,-0.623095733948568,tygrys,Czy Twoje dziecko mówi,mowa
+item48,2.86539778427088,-0.443349494424624,wąż,Czy Twoje dziecko mówi,mowa
+item49,3.47395289084047,-0.990159054609545,wiewiórka,Czy Twoje dziecko mówi,mowa
+item50,2.96993693359947,-0.701642003614226,wilk,Czy Twoje dziecko mówi,mowa
+item51,3.44085693791983,-0.718928057169007,zając,Czy Twoje dziecko mówi,mowa
+item52,3.89847589998845,-1.31138318763174,zwierzątko,Czy Twoje dziecko mówi,mowa
+item53,3.13465687491241,1.12051006346202,żaba,Czy Twoje dziecko mówi,mowa
+item54,3.34808342952557,-0.449956788744654,żółw,Czy Twoje dziecko mówi,mowa
+item55,3.35796868757938,-0.430813367310773,żyrafa,Czy Twoje dziecko mówi,mowa
+item56,2.79616252987389,3.88208230287244,auto samochód,Czy Twoje dziecko mówi,mowa
+item57,2.88781528830459,0.660360166497425,autobus,Czy Twoje dziecko mówi,mowa
+item58,2.03878017235658,-0.800085701210405,ciężarówka,Czy Twoje dziecko mówi,mowa
+item59,2.25699499671519,-0.895691107523421,helikopter,Czy Twoje dziecko mówi,mowa
+item60,2.33668513220646,0.009911210638064,koparka,Czy Twoje dziecko mówi,mowa
+item61,1.73854546694524,-0.778693397973674,lokomotywa,Czy Twoje dziecko mówi,mowa
+item62,3.06789212427141,0.501512214574968,motor motocykl,Czy Twoje dziecko mówi,mowa
+item63,2.67979700459355,1.00787985127384,pociąg,Czy Twoje dziecko mówi,mowa
+item64,2.01457503906214,-0.275292270880221,pogotowie karetka,Czy Twoje dziecko mówi,mowa
+item65,3.85891629232434,1.28797428634207,rower,Czy Twoje dziecko mówi,mowa
+item66,3.57332463948002,1.16127706112959,samolot,Czy Twoje dziecko mówi,mowa
+item67,3.46039421916528,-0.464990072262524,statek,Czy Twoje dziecko mówi,mowa
+item68,2.2379572222947,0.66052632010349,traktor,Czy Twoje dziecko mówi,mowa
+item69,2.03043663642895,-1.21135466349216,tramwaj,Czy Twoje dziecko mówi,mowa
+item70,3.70036154602374,2.10171506992813,banan,Czy Twoje dziecko mówi,mowa
+item71,2.66640733750154,-2.11881781522471,barszcz,Czy Twoje dziecko mówi,mowa
+item72,2.84822678520753,-0.627523910500339,batonik,Czy Twoje dziecko mówi,mowa
+item73,3.03555239404612,-0.838021095658786,budyń,Czy Twoje dziecko mówi,mowa
+item74,3.70077080956808,1.91511184559752,bułka,Czy Twoje dziecko mówi,mowa
+item75,3.68167647176701,-1.52311498198694,buraczki,Czy Twoje dziecko mówi,mowa
+item76,3.9732103265434,-0.771715248280607,cebula,Czy Twoje dziecko mówi,mowa
+item77,4.11440311320864,1.84104693854365,chleb,Czy Twoje dziecko mówi,mowa
+item78,3.42173403037943,0.779821625485124,chrupki,Czy Twoje dziecko mówi,mowa
+item79,3.05781139494001,0.233761468010514,ciasto,Czy Twoje dziecko mówi,mowa
+item80,3.37207924501847,1.01796489717297,ciastko,Czy Twoje dziecko mówi,mowa
+item81,3.63751499654773,-0.396852926008033,cukier,Czy Twoje dziecko mówi,mowa
+item82,2.96398383247705,0.560610218808009,cukierek,Czy Twoje dziecko mówi,mowa
+item83,3.96000868946006,0.72697770387098,czekolada,Czy Twoje dziecko mówi,mowa
+item84,3.07121900825454,-0.710882866527126,dżem,Czy Twoje dziecko mówi,mowa
+item85,3.50938585689332,-1.63811805158922,galaretka,Czy Twoje dziecko mówi,mowa
+item86,3.30630588998007,-1.6698295334219,groszek,Czy Twoje dziecko mówi,mowa
+item87,3.29150657210403,-1.26064117484785,grzyby,Czy Twoje dziecko mówi,mowa
+item88,2.19909926011273,-0.850692334237665,guma do żucia,Czy Twoje dziecko mówi,mowa
+item89,3.53549760845094,0.784457199217357,herbata,Czy Twoje dziecko mówi,mowa
+item90,4.49286859723825,1.96841483591151,jabłko,Czy Twoje dziecko mówi,mowa
+item91,3.33429078745904,2.67991313025076,jajko,Czy Twoje dziecko mówi,mowa
+item92,1.87958679759762,1.68994610161391,jedzenie papu am,Czy Twoje dziecko mówi,mowa
+item93,3.40767149089503,-0.015491434734933,jogurt,Czy Twoje dziecko mówi,mowa
+item94,2.62495219674413,-0.492927847326598,kakao,Czy Twoje dziecko mówi,mowa
+item95,3.85228862913924,-0.284351139879247,kanapka kromka,Czy Twoje dziecko mówi,mowa
+item96,4.33621486365009,-1.89373513005856,kapusta,Czy Twoje dziecko mówi,mowa
+item97,2.5895931140794,0.065687338305997,kaszka,Czy Twoje dziecko mówi,mowa
+item98,3.00116443118882,0.405029502287313,kawa,Czy Twoje dziecko mówi,mowa
+item99,3.50225657901622,-0.233038078292935,ketchup,Czy Twoje dziecko mówi,mowa
+item100,3.87560906088359,0.094254031119076,kiełbasa,Czy Twoje dziecko mówi,mowa
+item101,4.21339077052276,-0.628220634529254,kotlet,Czy Twoje dziecko mówi,mowa
+item102,3.85017241020299,-0.575882877559766,kurczak,Czy Twoje dziecko mówi,mowa
+item103,3.61334340885481,0.75641557985329,lizak,Czy Twoje dziecko mówi,mowa
+item104,3.82893031307262,1.16619915913008,lody,Czy Twoje dziecko mówi,mowa
+item105,4.54248226646636,-0.105101147022649,makaron kluski,Czy Twoje dziecko mówi,mowa
+item106,3.29679107681756,-1.57421802405547,mandarynka,Czy Twoje dziecko mówi,mowa
+item107,5.01570780129269,0.01849807210202,marchewka,Czy Twoje dziecko mówi,mowa
+item108,4.51147242024619,-0.462858772455702,masło margaryna,Czy Twoje dziecko mówi,mowa
+item109,4.25580202594268,0.298258535538589,mięso,Czy Twoje dziecko mówi,mowa
+item110,3.3495944795517,-1.47524264970013,miód,Czy Twoje dziecko mówi,mowa
+item111,3.82777199442414,1.88145142575845,mleko,Czy Twoje dziecko mówi,mowa
+item112,3.93805597030011,-1.10795471465477,naleśniki,Czy Twoje dziecko mówi,mowa
+item113,4.26003663262629,-2.03656952466318,orzechy,Czy Twoje dziecko mówi,mowa
+item114,4.15636017655103,0.17346066665398,ogórek,Czy Twoje dziecko mówi,mowa
+item115,4.1467126956232,-0.048670817941587,paluszki,Czy Twoje dziecko mówi,mowa
+item116,4.25015889798738,0.57177766038788,parówka kiełbaska,Czy Twoje dziecko mówi,mowa
+item117,2.63140981407053,1.94819041808443,picie,Czy Twoje dziecko mówi,mowa
+item118,3.48643030297562,-1.35273115509687,pierogi,Czy Twoje dziecko mówi,mowa
+item119,3.66712160724013,-1.35734040007015,placek,Czy Twoje dziecko mówi,mowa
+item120,4.05350428538001,-1.5972770996663,pomarańcza,Czy Twoje dziecko mówi,mowa
+item121,4.53893794465695,0.139978605159524,pomidor,Czy Twoje dziecko mówi,mowa
+item122,3.26600613687271,-2.34190851027065,rodzynki,Czy Twoje dziecko mówi,mowa
+item123,3.96602476936488,-0.47398246516191,rosół,Czy Twoje dziecko mówi,mowa
+item124,3.49802257401074,0.732024153704012,ryba,Czy Twoje dziecko mówi,mowa
+item125,3.70161889537777,-0.919959679435524,ryż,Czy Twoje dziecko mówi,mowa
+item126,4.08487059061328,0.34689565960189,ser,Czy Twoje dziecko mówi,mowa
+item127,3.63502302983927,1.41058855994297,sok,Czy Twoje dziecko mówi,mowa
+item128,3.1264415586161,-0.824860964086983,sos,Czy Twoje dziecko mówi,mowa
+item129,3.56072459525807,-0.87949027645159,sól,Czy Twoje dziecko mówi,mowa
+item130,3.70847506832051,-0.948075529478284,szynka,Czy Twoje dziecko mówi,mowa
+item131,4.50627737782944,-0.772525904218574,truskawki,Czy Twoje dziecko mówi,mowa
+item132,3.55556043431518,-2.10019328418155,witaminy,Czy Twoje dziecko mówi,mowa
+item133,3.44413516318343,1.51786913075718,woda,Czy Twoje dziecko mówi,mowa
+item134,4.57689794313489,-0.095162581576569,ziemniaki kartofle,Czy Twoje dziecko mówi,mowa
+item135,4.58990530512909,1.85281106839536,zupa,Czy Twoje dziecko mówi,mowa
+item136,3.58010188515902,2.74615232265816,bajka,Czy Twoje dziecko mówi,mowa
+item137,3.87326222445759,1.32879144902213,balonik,Czy Twoje dziecko mówi,mowa
+item138,3.61922580788279,-0.816673561605505,grabki,Czy Twoje dziecko mówi,mowa
+item139,3.35498549047953,-0.430538535835007,gumka,Czy Twoje dziecko mówi,mowa
+item140,4.97485036024411,0.145185812796946,kartka papier,Czy Twoje dziecko mówi,mowa
+item141,4.79232715155271,2.25954620499718,klocki,Czy Twoje dziecko mówi,mowa
+item142,4.71677550457317,1.51548987017919,kredki,Czy Twoje dziecko mówi,mowa
+item143,5.00146657596902,1.00382784665052,książka,Czy Twoje dziecko mówi,mowa
+item144,2.02901243242628,1.61628942590715,lalka,Czy Twoje dziecko mówi,mowa
+item145,4.79864864900391,-0.016493980396522,łopatka,Czy Twoje dziecko mówi,mowa
+item146,5.24199748556152,-1.12490936254764,obrazek,Czy Twoje dziecko mówi,mowa
+item147,3.45701357042948,-0.956761723068334,ołówek,Czy Twoje dziecko mówi,mowa
+item148,3.5006846967276,2.87939328636091,piłka,Czy Twoje dziecko mówi,mowa
+item149,3.33912413799082,0.221099833321611,pisak długopis,Czy Twoje dziecko mówi,mowa
+item150,5.31921341753221,-0.993202258361264,prezent,Czy Twoje dziecko mówi,mowa
+item151,2.04762049577794,0.497612172111375,smoczek,Czy Twoje dziecko mówi,mowa
+item152,5.30581073809855,-0.077512036735751,wiaderko,Czy Twoje dziecko mówi,mowa
+item153,5.35398058590273,0.606092334095908,zabawka,Czy Twoje dziecko mówi,mowa
+item154,4.8297985071551,0.370993226977647,bluzka,Czy Twoje dziecko mówi,mowa
+item155,3.87393580975759,3.00479744042494,buty,Czy Twoje dziecko mówi,mowa
+item156,3.76127560605651,-1.53059476987784,chustka,Czy Twoje dziecko mówi,mowa
+item157,4.63623789690107,2.4511754345948,czapka,Czy Twoje dziecko mówi,mowa
+item158,3.90854085136181,-0.500558424335543,guzik,Czy Twoje dziecko mówi,mowa
+item159,4.05331814794583,-0.397693903764823,kalosze gumowce,Czy Twoje dziecko mówi,mowa
+item160,3.9084939440826,-1.36190517509009,kapelusz,Czy Twoje dziecko mówi,mowa
+item161,4.83884399980748,-0.886953507101918,kieszeń,Czy Twoje dziecko mówi,mowa
+item162,4.10913240134152,-1.31003883818332,koszula,Czy Twoje dziecko mówi,mowa
+item163,5.65067486485322,1.42848029088935,kurtka,Czy Twoje dziecko mówi,mowa
+item164,4.70787914900312,0.471688131613001,majtki,Czy Twoje dziecko mówi,mowa
+item165,3.3925211922188,-0.316786039304124,pantofle kapcie,Czy Twoje dziecko mówi,mowa
+item166,3.66331997611227,-1.28345779028428,pasek,Czy Twoje dziecko mówi,mowa
+item167,3.68800709464829,0.851632547158672,pieluszka pampers,Czy Twoje dziecko mówi,mowa
+item168,4.57543754954659,-0.048795958903294,piżama,Czy Twoje dziecko mówi,mowa
+item169,4.18769701778991,-0.571823842022659,rajstopy rajtuzy,Czy Twoje dziecko mówi,mowa
+item170,4.34049882276578,-0.389387272741751,rękawiczki,Czy Twoje dziecko mówi,mowa
+item171,4.84006931171715,1.2172614330003,skarpetki,Czy Twoje dziecko mówi,mowa
+item172,5.18062958041206,1.05440190524264,spodnie,Czy Twoje dziecko mówi,mowa
+item173,3.90503797950694,-1.04414381138966,sukienka,Czy Twoje dziecko mówi,mowa
+item174,4.73146430357083,-1.05612740292325,sweter,Czy Twoje dziecko mówi,mowa
+item175,4.54301335876412,-0.434384346663432,szalik,Czy Twoje dziecko mówi,mowa
+item176,3.04879713794747,-1.62227650300281,śliniaczek,Czy Twoje dziecko mówi,mowa
+item177,4.82605722636323,-0.401168814191889,ubranie,Czy Twoje dziecko mówi,mowa
+item178,3.60544912542157,-0.279884791213348,broda,Czy Twoje dziecko mówi,mowa
+item179,5.60190585988923,2.5166824038804,brzuch,Czy Twoje dziecko mówi,mowa
+item180,4.46695985186373,2.02845464424838,buzia,Czy Twoje dziecko mówi,mowa
+item181,3.8791698260206,0.125552198792237,czoło,Czy Twoje dziecko mówi,mowa
+item182,3.9385536300404,-1.05613391681908,gardło,Czy Twoje dziecko mówi,mowa
+item183,5.77203346099232,2.33239103340999,głowa,Czy Twoje dziecko mówi,mowa
+item184,4.64114022228949,0.138537639192172,język,Czy Twoje dziecko mówi,mowa
+item185,5.21578396687651,0.078961122542563,kolano,Czy Twoje dziecko mówi,mowa
+item186,3.52595829946088,-1.54857778807847,krew,Czy Twoje dziecko mówi,mowa
+item187,3.44141093387501,-1.96709619501928,łokieć,Czy Twoje dziecko mówi,mowa
+item188,5.27036238597599,2.63421080785661,noga,Czy Twoje dziecko mówi,mowa
+item189,4.05831237483107,3.28441309244961,nos,Czy Twoje dziecko mówi,mowa
+item190,3.39262246674015,3.35910294298266,oko,Czy Twoje dziecko mówi,mowa
+item191,5.16006007101355,1.25607640540455,palec,Czy Twoje dziecko mówi,mowa
+item192,5.3054506811203,-0.912190395486372,paznokcie pazurki,Czy Twoje dziecko mówi,mowa
+item193,3.39101071757001,0.842993890356853,pępek,Czy Twoje dziecko mówi,mowa
+item194,4.91757720843828,-0.114538335778022,plecy,Czy Twoje dziecko mówi,mowa
+item195,4.35491786402075,-0.862184716667488,policzek,Czy Twoje dziecko mówi,mowa
+item196,3.46762868792203,2.49976038100412,pupa,Czy Twoje dziecko mówi,mowa
+item197,5.59644512411004,1.96894717543251,ręka,Czy Twoje dziecko mówi,mowa
+item198,3.69680766036274,-1.26998679492531,serce,Czy Twoje dziecko mówi,mowa
+item199,4.06167600912195,-2.12403676547492,skóra,Czy Twoje dziecko mówi,mowa
+item200,4.12707912358052,-0.142880547807043,szyja,Czy Twoje dziecko mówi,mowa
+item201,4.26836693093557,2.38126407507583,ucho,Czy Twoje dziecko mówi,mowa
+item202,5.44436613597001,2.06860977406305,włosy,Czy Twoje dziecko mówi,mowa
+item203,5.33549320874598,1.14841222148734,ząb,Czy Twoje dziecko mówi,mowa
+item204,3.01057236972695,-0.99750868383892,balkon,Czy Twoje dziecko mówi,mowa
+item205,3.41841627034266,-0.798258462949491,dach,Czy Twoje dziecko mówi,mowa
+item206,4.60485705253676,2.12122634117923,drzwi,Czy Twoje dziecko mówi,mowa
+item207,4.80936227695451,-0.25911036515519,dywan,Czy Twoje dziecko mówi,mowa
+item208,3.92887786161942,-1.32932515404336,firanka zasłona,Czy Twoje dziecko mówi,mowa
+item209,4.35759277227131,-0.167313502891168,fotel,Czy Twoje dziecko mówi,mowa
+item210,3.86259645296057,-2.30101477135512,korytarz przedpokój,Czy Twoje dziecko mówi,mowa
+item211,4.08366037647805,-1.02970011109032,kran,Czy Twoje dziecko mówi,mowa
+item212,5.11597694973399,0.917837393920002,krzesło,Czy Twoje dziecko mówi,mowa
+item213,5.81805481677154,0.430746674357415,kuchnia,Czy Twoje dziecko mówi,mowa
+item214,5.38435867332375,0.041382928616514,lodówka,Czy Twoje dziecko mówi,mowa
+item215,5.53885828543339,0.050165065562225,łazienka,Czy Twoje dziecko mówi,mowa
+item216,5.68112109939801,1.28021771622585,łóżko,Czy Twoje dziecko mówi,mowa
+item217,3.99621153779218,-0.08060373351507,odkurzacz,Czy Twoje dziecko mówi,mowa
+item218,4.48126248157205,1.57307243262679,okno,Czy Twoje dziecko mówi,mowa
+item219,5.8765135549827,-0.759256865386402,podłoga,Czy Twoje dziecko mówi,mowa
+item220,5.99003524578335,0.372653101170724,pokój,Czy Twoje dziecko mówi,mowa
+item221,4.54334110990617,-2.12356525287887,półka regał,Czy Twoje dziecko mówi,mowa
+item222,5.05558363896948,0.1368940201459,pralka,Czy Twoje dziecko mówi,mowa
+item223,3.94924129213452,-1.39285984686685,prysznic,Czy Twoje dziecko mówi,mowa
+item224,5.73332674134089,0.047509677813068,schody,Czy Twoje dziecko mówi,mowa
+item225,3.67805613899343,-1.56380928525796,stołek,Czy Twoje dziecko mówi,mowa
+item226,5.90018461774569,1.21783794635013,stół,Czy Twoje dziecko mówi,mowa
+item227,4.06600585920625,-2.09428061685936,sufit,Czy Twoje dziecko mówi,mowa
+item228,5.53379922769509,-0.09658395052903,szafa,Czy Twoje dziecko mówi,mowa
+item229,4.87266983190882,-1.83598742794658,szuflada,Czy Twoje dziecko mówi,mowa
+item230,5.47514933976087,-0.931474493661421,ściana,Czy Twoje dziecko mówi,mowa
+item231,4.49252938978059,0.778441922455318,telewizor,Czy Twoje dziecko mówi,mowa
+item232,3.3146042952583,-0.947134980670909,ubikacja ustęp,Czy Twoje dziecko mówi,mowa
+item233,4.11778478650876,0.106159628085169,wanna,Czy Twoje dziecko mówi,mowa
+item234,4.65483503125409,1.07030843181057,wózek,Czy Twoje dziecko mówi,mowa
+item235,3.7328891416757,-0.984479804612667,aparat kamera,Czy Twoje dziecko mówi,mowa
+item236,4.39013998032533,1.27108413855085,butelka,Czy Twoje dziecko mówi,mowa
+item237,4.01607138958727,-1.11628540549631,czajnik,Czy Twoje dziecko mówi,mowa
+item238,4.16995141143687,-1.59459375490083,deska,Czy Twoje dziecko mówi,mowa
+item239,5.15891423252202,-0.417094087591993,garnek,Czy Twoje dziecko mówi,mowa
+item240,4.69680677278124,-0.886363366052308,gazeta,Czy Twoje dziecko mówi,mowa
+item241,3.87842439149165,-0.978018170627906,grzebień,Czy Twoje dziecko mówi,mowa
+item242,3.55607711674471,-2.02272509770383,igła,Czy Twoje dziecko mówi,mowa
+item243,4.62974751116848,0.914294769858367,klucz,Czy Twoje dziecko mówi,mowa
+item244,4.2620036512069,0.935831465609202,koc kołdra,Czy Twoje dziecko mówi,mowa
+item245,4.53502649727847,-1.28988359935114,koszyk,Czy Twoje dziecko mówi,mowa
+item246,4.86395054270569,1.22815417536289,kubek,Czy Twoje dziecko mówi,mowa
+item247,3.6724314666663,0.373655748564995,lampa,Czy Twoje dziecko mówi,mowa
+item248,4.43291083668597,-1.10807191905695,lekarstwa tabletki,Czy Twoje dziecko mówi,mowa
+item249,5.3878855774249,-0.468013805103988,lustro,Czy Twoje dziecko mówi,mowa
+item250,5.55796061564914,1.15678125019844,łyżka,Czy Twoje dziecko mówi,mowa
+item251,3.14562248548399,-1.01392011419125,miotła,Czy Twoje dziecko mówi,mowa
+item252,4.42534028209906,0.016149034623781,miska,Czy Twoje dziecko mówi,mowa
+item253,4.10146955464106,-1.19465689483842,młotek,Czy Twoje dziecko mówi,mowa
+item254,4.9073853579077,0.442307593252009,mydło,Czy Twoje dziecko mówi,mowa
+item255,3.39256291670381,-2.07256735765508,nici,Czy Twoje dziecko mówi,mowa
+item256,4.01650227076491,0.736084346613317,nocnik,Czy Twoje dziecko mówi,mowa
+item257,4.68170209205496,-0.577943349813542,nożyczki,Czy Twoje dziecko mówi,mowa
+item258,3.7717522549989,0.243546242583344,nóż,Czy Twoje dziecko mówi,mowa
+item259,4.86199612951555,-1.61731344364831,obraz,Czy Twoje dziecko mówi,mowa
+item260,4.55738499450008,0.625348040552958,okulary,Czy Twoje dziecko mówi,mowa
+item261,4.50308212094235,-0.27785359714811,pieniądze,Czy Twoje dziecko mówi,mowa
+item262,5.15183055505832,0.447350053478135,poduszka,Czy Twoje dziecko mówi,mowa
+item263,6.1563915393497,-1.56883205245505,pudełko,Czy Twoje dziecko mówi,mowa
+item264,3.5884768519032,-0.850167412743441,radio,Czy Twoje dziecko mówi,mowa
+item265,5.8918627713867,-0.274321047890372,ręcznik,Czy Twoje dziecko mówi,mowa
+item266,5.23168957019503,-2.17030718482132,słoik,Czy Twoje dziecko mówi,mowa
+item267,4.60571094174148,-0.496742203326518,syrop,Czy Twoje dziecko mówi,mowa
+item268,4.32228553734227,-0.029182475888578,szczoteczka do zębów,Czy Twoje dziecko mówi,mowa
+item269,4.43888241561489,-0.762903828991904,szczotka,Czy Twoje dziecko mówi,mowa
+item270,4.70429910020404,-0.542731922361847,szklanka,Czy Twoje dziecko mówi,mowa
+item271,4.71970960899772,-1.56998143419658,szmata ścierka,Czy Twoje dziecko mówi,mowa
+item272,4.81791175390622,-2.31312756693522,sznurek,Czy Twoje dziecko mówi,mowa
+item273,4.48542737413765,0.495385984855583,śmieci,Czy Twoje dziecko mówi,mowa
+item274,5.27228796106478,0.126926993374197,talerz,Czy Twoje dziecko mówi,mowa
+item275,3.52330074656456,1.47980561856498,telefon komórka,Czy Twoje dziecko mówi,mowa
+item276,4.12191131803299,-1.93375953551041,termometr,Czy Twoje dziecko mówi,mowa
+item277,5.08808027690127,-0.561637510820281,torebka,Czy Twoje dziecko mówi,mowa
+item278,5.51121581584678,-0.243130823368633,widelec,Czy Twoje dziecko mówi,mowa
+item279,3.60627090096753,-1.85243074180111,zapałki,Czy Twoje dziecko mówi,mowa
+item280,5.0868292417988,-0.642100777779233,zdjęcie fotografia,Czy Twoje dziecko mówi,mowa
+item281,4.11989044596248,0.092160854070879,zegarek,Czy Twoje dziecko mówi,mowa
+item282,3.96497390689574,-1.39742275870889,żelazko,Czy Twoje dziecko mówi,mowa
+item283,3.72887707310793,-1.06023978002441,bałwan,Czy Twoje dziecko mówi,mowa
+item284,3.98910989097436,-0.536355205243472,błoto,Czy Twoje dziecko mówi,mowa
+item285,3.96316357758338,0.133131936287828,burza,Czy Twoje dziecko mówi,mowa
+item286,4.77663634473556,-0.392545825162705,chmura,Czy Twoje dziecko mówi,mowa
+item287,4.30138192812995,1.87542188151542,deszcz,Czy Twoje dziecko mówi,mowa
+item288,4.32797642335008,-1.5876604957315,drabina,Czy Twoje dziecko mówi,mowa
+item289,4.56712417462748,-0.192946311202057,droga,Czy Twoje dziecko mówi,mowa
+item290,5.46417087710277,1.26431174706288,drzewo,Czy Twoje dziecko mówi,mowa
+item291,4.01440767738524,-2.56086697459215,gałąź,Czy Twoje dziecko mówi,mowa
+item292,4.75741478957074,-0.661523320574645,gwiazda,Czy Twoje dziecko mówi,mowa
+item293,3.42543406223646,0.969006757878171,huśtawka,Czy Twoje dziecko mówi,mowa
+item294,5.85531245274438,0.152427124326961,kamień,Czy Twoje dziecko mówi,mowa
+item295,4.4683681937424,0.087140539532855,kijek patyk,Czy Twoje dziecko mówi,mowa
+item296,4.21763889668422,-0.380922721883885,księżyc,Czy Twoje dziecko mówi,mowa
+item297,4.92661175502414,1.44722293559552,kwiatek,Czy Twoje dziecko mówi,mowa
+item298,5.16465233465969,0.037676840761488,listek,Czy Twoje dziecko mówi,mowa
+item299,3.69112033295798,-1.36442322784635,most,Czy Twoje dziecko mówi,mowa
+item300,3.43862640965839,-2.33904719940919,mróz,Czy Twoje dziecko mówi,mowa
+item301,4.33470445621928,0.259755120302975,niebo,Czy Twoje dziecko mówi,mowa
+item302,3.64633156333809,-0.474804131851309,ogień,Czy Twoje dziecko mówi,mowa
+item303,5.51822911915937,0.654692146768858,piasek piaskownica,Czy Twoje dziecko mówi,mowa
+item304,4.26285990337202,-1.35103436098654,płot,Czy Twoje dziecko mówi,mowa
+item305,4.54071268160746,-1.3450047265219,sanki,Czy Twoje dziecko mówi,mowa
+item306,5.22597679583392,0.861698566081087,słońce,Czy Twoje dziecko mówi,mowa
+item307,4.64203043379989,-0.882938759574271,śnieg,Czy Twoje dziecko mówi,mowa
+item308,5.90462851706224,0.617171074172548,trawa,Czy Twoje dziecko mówi,mowa
+item309,4.55651738771032,-0.848086669427381,ulica,Czy Twoje dziecko mówi,mowa
+item310,5.01070939130415,-0.40193613011229,wiatr,Czy Twoje dziecko mówi,mowa
+item311,4.30862374186378,1.95622630009381,woda,Czy Twoje dziecko mówi,mowa
+item312,4.51431535769152,-1.26348199424888,ziemia,Czy Twoje dziecko mówi,mowa
+item313,3.54590149968045,-1.99894179656885,apteka,Czy Twoje dziecko mówi,mowa
+item314,4.11891061567544,2.93519293510791,dom,Czy Twoje dziecko mówi,mowa
+item315,2.84158731287497,-1.73326496345738,góry,Czy Twoje dziecko mówi,mowa
+item316,4.0086002394664,-1.50836919151033,imieniny urodziny,Czy Twoje dziecko mówi,mowa
+item317,3.3886328113444,-0.474151863036315,kościół,Czy Twoje dziecko mówi,mowa
+item318,3.3007998766248,0.156173181525869,las,Czy Twoje dziecko mówi,mowa
+item319,3.62227036317649,-1.72163330753192,miasto,Czy Twoje dziecko mówi,mowa
+item320,3.14995071597493,-1.13499376606287,morze,Czy Twoje dziecko mówi,mowa
+item321,3.33374561676871,0.659789026144783,na dwór na pole,Czy Twoje dziecko mówi,mowa
+item322,3.98494360996649,-1.10918010925119,park ogród,Czy Twoje dziecko mówi,mowa
+item323,3.35779102393284,-2.28223992152361,poczta,Czy Twoje dziecko mówi,mowa
+item324,3.25542587345117,-0.769576897686614,podwórko,Czy Twoje dziecko mówi,mowa
+item325,3.70873098132428,0.231057726367272,praca,Czy Twoje dziecko mówi,mowa
+item326,3.77761991037021,-1.83893052192395,rzeka,Czy Twoje dziecko mówi,mowa
+item327,4.87131764356184,1.21892438658417,sklep,Czy Twoje dziecko mówi,mowa
+item328,4.15825426343678,0.863409883484773,spacer,Czy Twoje dziecko mówi,mowa
+item329,4.04422875265821,0.103874733656313,szkoła przedszkole,Czy Twoje dziecko mówi,mowa
+item330,2.65998601859295,-0.961581104772431,zoo,Czy Twoje dziecko mówi,mowa
+item331,2.45673221979816,4.41196706616813,babcia,Czy Twoje dziecko mówi,mowa
+item332,2.37674945071436,-0.686528008691962,brat,Czy Twoje dziecko mówi,mowa
+item333,4.37844184797596,0.296935515776441,chłopiec,Czy Twoje dziecko mówi,mowa
+item334,2.8599787624139,2.49565998392124,ciocia,Czy Twoje dziecko mówi,mowa
+item335,3.58471842794192,-1.50938914436559,córeczka,Czy Twoje dziecko mówi,mowa
+item336,5.31455596409013,0.093065335861351,doktor lekarz,Czy Twoje dziecko mówi,mowa
+item337,2.08533240492028,2.5769435580716,dziadek dziadzio,Czy Twoje dziecko mówi,mowa
+item338,1.84656038769314,1.92129581478979,dzidzi dzidziuś,Czy Twoje dziecko mówi,mowa
+item339,3.20654567447172,1.86525212455521,dzieci,Czy Twoje dziecko mówi,mowa
+item340,4.21537116880529,0.677397301138075,dziewczynka,Czy Twoje dziecko mówi,mowa
+item341,4.04821545650718,-2.07618992782269,fryzjer,Czy Twoje dziecko mówi,mowa
+item342,4.2947544476394,-1.20588952509478,goście,Czy Twoje dziecko mówi,mowa
+item343,2.13440501753978,0.131912199192953,imię zwierzątka,Czy Twoje dziecko mówi,mowa
+item344,4.48887010763202,-1.33711308283869,kolega koleżanka,Czy Twoje dziecko mówi,mowa
+item345,4.02341724791058,-2.1916592854638,krasnoludek,Czy Twoje dziecko mówi,mowa
+item346,4.25344528423066,-1.33321028488282,król królewna,Czy Twoje dziecko mówi,mowa
+item347,3.41537887458111,-1.74355124248287,ksiądz,Czy Twoje dziecko mówi,mowa
+item348,4.4393946562971,-1.16166491362176,ludzie,Czy Twoje dziecko mówi,mowa
+item349,1.21485427714695,3.70008319255559,mama mamusia,Czy Twoje dziecko mówi,mowa
+item350,3.19668778869141,2.51677671730889,pan,Czy Twoje dziecko mówi,mowa
+item351,3.43428443313442,1.99893328263737,pani,Czy Twoje dziecko mówi,mowa
+item352,4.22973172060913,-1.44409528122617,policjant,Czy Twoje dziecko mówi,mowa
+item353,2.80947962497562,-0.877149768733592,siostra,Czy Twoje dziecko mówi,mowa
+item354,3.66675202468882,-1.15802079096017,synek,Czy Twoje dziecko mówi,mowa
+item355,1.41476161419384,3.57589978463702,tata tatuś,Czy Twoje dziecko mówi,mowa
+item356,2.33504698879621,1.5454036086787,własne imię,Czy Twoje dziecko mówi,mowa
+item357,3.06517017569379,1.08599027574489,wujek,Czy Twoje dziecko mówi,mowa
+item358,2.09078446148401,1.93473866120572,cześć,Czy Twoje dziecko mówi,mowa
+item359,3.72083890878191,0.498699587418552,dzień dobry,Czy Twoje dziecko mówi,mowa
+item360,3.37439896663492,0.342696045402409,do widzenia,Czy Twoje dziecko mówi,mowa
+item361,3.69721406549373,0.011914555185596,dobranoc,Czy Twoje dziecko mówi,mowa
+item362,3.82497280973113,1.52181136586606,dziękuję,Czy Twoje dziecko mówi,mowa
+item363,3.76952850302315,1.33968894219705,proszę,Czy Twoje dziecko mówi,mowa
+item364,4.27964454839401,0.469063085504534,przepraszam,Czy Twoje dziecko mówi,mowa
+item365,1.48230133139065,1.34693262921587,halo,Czy Twoje dziecko mówi,mowa
+item366,1.52229241024244,3.84518556925825,pa pa ,Czy Twoje dziecko mówi,mowa
+item367,2.02631510388727,3.21806758967314,tak,Czy Twoje dziecko mówi,mowa
+item368,1.61467307480406,3.4037152461555,nie,Czy Twoje dziecko mówi,mowa
+item369,4.4175276188752,-0.243905948041326,śniadanie,Czy Twoje dziecko mówi,mowa
+item370,4.48825502642421,0.339667814312223,obiad,Czy Twoje dziecko mówi,mowa
+item371,4.3830255633827,-0.714398681174667,kolacja,Czy Twoje dziecko mówi,mowa
+item372,2.29261704307047,2.68598503608634,siusiu siku sisi,Czy Twoje dziecko mówi,mowa
+item373,2.72095864489492,1.85099938818426,kupka,Czy Twoje dziecko mówi,mowa
+item374,1.57474316481998,0.474741757293684,kosi kosi łapci,Czy Twoje dziecko mówi,mowa
+item375,2.49886741756669,-0.167512412395661,idzie rak nieborak,Czy Twoje dziecko mówi,mowa
+item376,1.7346133039097,-0.698305726316943,sroczka kaszkę warzyła,Czy Twoje dziecko mówi,mowa
+item377,0.63712132659387,1.53724139538549,be,Czy Twoje dziecko mówi,mowa
+item378,4.03016656594882,-1.23074714414019,biały,Czy Twoje dziecko mówi,mowa
+item379,4.29169678360483,0.717628219492417,brudny,Czy Twoje dziecko mówi,mowa
+item380,4.09620223699928,-0.339577460285012,brzydki,Czy Twoje dziecko mówi,mowa
+item381,1.05564938715895,-0.087394411453255,cacy cacany,Czy Twoje dziecko mówi,mowa
+item382,5.57978599981654,0.271629053251373,chory,Czy Twoje dziecko mówi,mowa
+item383,3.72803001781075,0.335647499978334,ciepły,Czy Twoje dziecko mówi,mowa
+item384,4.70420263911428,-0.806308936980746,ciężki,Czy Twoje dziecko mówi,mowa
+item385,4.84419272976346,-1.77409196880913,czarny,Czy Twoje dziecko mówi,mowa
+item386,4.29466291118114,-1.42143795021124,czerwony,Czy Twoje dziecko mówi,mowa
+item387,5.17127271380513,0.026317468728568,czysty,Czy Twoje dziecko mówi,mowa
+item388,4.00954895711604,0.418609896090162,dobry,Czy Twoje dziecko mówi,mowa
+item389,4.2728669302271,1.17741901943694,duży,Czy Twoje dziecko mówi,mowa
+item390,4.82761316676685,-0.401270303972072,głodny,Czy Twoje dziecko mówi,mowa
+item391,3.35202133117663,-1.45434884272608,głupi,Czy Twoje dziecko mówi,mowa
+item393,4.13645335734009,-0.590209532839311,kochany,Czy Twoje dziecko mówi,mowa
+item394,4.48619337609596,-0.089294309319324,ładny,Czy Twoje dziecko mówi,mowa
+item395,4.35876532726501,0.742554669317351,mały,Czy Twoje dziecko mówi,mowa
+item396,4.35738133223045,-2.19204334393046,mądry,Czy Twoje dziecko mówi,mowa
+item397,4.6802546152372,-0.132881479524677,mokry,Czy Twoje dziecko mówi,mowa
+item398,4.42036197897981,-0.259074168495517, nie grzeczny,Czy Twoje dziecko mówi,mowa
+item399,4.40103351378431,-1.05996025690371,nowy,Czy Twoje dziecko mówi,mowa
+item400,4.62905062612088,-1.61009641869834,otwarty,Czy Twoje dziecko mówi,mowa
+item401,4.09112430622234,-1.52410077826909,piękny śliczny,Czy Twoje dziecko mówi,mowa
+item402,3.4186998446416,-0.403832697950302,pyszny,Czy Twoje dziecko mówi,mowa
+item403,3.27949369140517,-0.396008204969395,śpiący,Czy Twoje dziecko mówi,mowa
+item404,4.73928682595149,-0.675664206206732,umyty,Czy Twoje dziecko mówi,mowa
+item405,4.8152894914941,-1.26287993542603,zamknięty,Czy Twoje dziecko mówi,mowa
+item406,5.75416269515672,-1.12396521110862,zdrowy,Czy Twoje dziecko mówi,mowa
+item407,4.21697518928633,-1.13237865909683,zepsuty,Czy Twoje dziecko mówi,mowa
+item408,3.814776447238,0.356006392836455,zimny,Czy Twoje dziecko mówi,mowa
+item409,4.84263734483848,-1.17877631896237,zmęczony,Czy Twoje dziecko mówi,mowa
+item410,3.36197187142903,-0.278789522473532,boso na bosaka,Czy Twoje dziecko mówi,mowa
+item411,3.40275675858086,-0.374106672875274,brzydko,Czy Twoje dziecko mówi,mowa
+item412,2.63427388338166,1.4231880915538,cicho,Czy Twoje dziecko mówi,mowa
+item413,5.31985894082286,0.905617661585033,ciemno,Czy Twoje dziecko mówi,mowa
+item414,4.51228771851777,0.477986915241562,ciepło,Czy Twoje dziecko mówi,mowa
+item415,3.86694682861182,0.507122914531065,dobrze,Czy Twoje dziecko mówi,mowa
+item416,5.16236936726142,-0.452120072467262,głośno,Czy Twoje dziecko mówi,mowa
+item418,4.52543853872486,-0.330176927387453,ładnie,Czy Twoje dziecko mówi,mowa
+item419,4.64972314426082,-1.01881055943154,mocno,Czy Twoje dziecko mówi,mowa
+item420,4.02439707659751,0.218090071784516,mokro,Czy Twoje dziecko mówi,mowa
+item421,4.80756178523898,-0.367387893157547,prędko szybko,Czy Twoje dziecko mówi,mowa
+item422,3.68021637372658,0.86307106263479,zimno,Czy Twoje dziecko mówi,mowa
+item423,3.57160630388861,0.41446258727418,bać się,Czy Twoje dziecko mówi,mowa
+item424,5.45989169682233,1.34147490083676,bawić się,Czy Twoje dziecko mówi,mowa
+item425,3.05570777086581,-0.128247528322277,bić,Czy Twoje dziecko mówi,mowa
+item426,5.77545540165528,0.269796784376949,biec biegać,Czy Twoje dziecko mówi,mowa
+item427,3.29383315648934,0.594273255659256,boleć,Czy Twoje dziecko mówi,mowa
+item428,5.42568131517071,-0.409941890558193,budować,Czy Twoje dziecko mówi,mowa
+item429,3.04863373221261,-0.017371828127395,być  jest ,Czy Twoje dziecko mówi,mowa
+item430,4.08246023936735,-0.113946774727708,całować,Czy Twoje dziecko mówi,mowa
+item431,3.3343754499887,0.189263688004994,chcieć,Czy Twoje dziecko mówi,mowa
+item432,3.7104534098885,1.03926610895408,chodzić  chodź ,Czy Twoje dziecko mówi,mowa
+item433,3.41020684013962,-1.72791242610884,ciąć,Czy Twoje dziecko mówi,mowa
+item434,4.76655708400019,-1.12379758931582,cieszyć się,Czy Twoje dziecko mówi,mowa
+item435,4.93386647942281,-0.586709044230999,czekać,Czy Twoje dziecko mówi,mowa
+item436,4.61266233779689,-0.282772090127865,czesać,Czy Twoje dziecko mówi,mowa
+item437,4.57514612766049,-1.59378470315694,czyścić,Czy Twoje dziecko mówi,mowa
+item438,4.74729404660244,0.607568175080387,czytać,Czy Twoje dziecko mówi,mowa
+item439,2.08170707610367,1.42353295579918,dać,Czy Twoje dziecko mówi,mowa
+item440,4.55515217659803,-0.424933727685594,dmuchać,Czy Twoje dziecko mówi,mowa
+item441,5.1826176855485,-1.22131661776693,dostać,Czy Twoje dziecko mówi,mowa
+item442,5.30391576530077,-1.70441336209153,drapać,Czy Twoje dziecko mówi,mowa
+item443,4.41877286622377,0.617554299393074,dzwonić,Czy Twoje dziecko mówi,mowa
+item444,4.19929541396329,-0.826797609553851,gonić,Czy Twoje dziecko mówi,mowa
+item445,5.71463049750884,-0.446381080001825,gotować,Czy Twoje dziecko mówi,mowa
+item446,4.66293978166755,0.01400184170221,grać,Czy Twoje dziecko mówi,mowa
+item447,5.17772718809402,-1.07101298342728,gryźć,Czy Twoje dziecko mówi,mowa
+item448,3.29958160953119,0.864379651717812,huśtać bujać się,Czy Twoje dziecko mówi,mowa
+item449,3.19391042363779,1.43095897616213,iść pójść,Czy Twoje dziecko mówi,mowa
+item450,3.99021880743085,0.901716685469006,jechać jeździć,Czy Twoje dziecko mówi,mowa
+item451,2.78975250292023,1.80673229431208,jeść,Czy Twoje dziecko mówi,mowa
+item452,3.97904687187879,1.23271459964587,kąpać się,Czy Twoje dziecko mówi,mowa
+item453,4.48182901765037,-0.640010056697782,kłaść położyć,Czy Twoje dziecko mówi,mowa
+item454,4.38784649540436,0.356823408030941,kochać,Czy Twoje dziecko mówi,mowa
+item455,4.51515370619022,-0.669835106235948,kopać,Czy Twoje dziecko mówi,mowa
+item456,5.74244682771086,-0.919405993809089,krzyczeć wołać,Czy Twoje dziecko mówi,mowa
+item457,5.96649418343249,0.214954999565448,kupić,Czy Twoje dziecko mówi,mowa
+item458,3.40427119636664,-1.84876807947785,lać,Czy Twoje dziecko mówi,mowa
+item459,4.56602539529957,-1.206029260096,lecieć latać,Czy Twoje dziecko mówi,mowa
+item460,5.63564137903958,-0.29075419932307,leżeć,Czy Twoje dziecko mówi,mowa
+item461,5.31255094227945,-0.492523021400935,lubić,Czy Twoje dziecko mówi,mowa
+item462,4.68326836994383,0.150524961214896,malować,Czy Twoje dziecko mówi,mowa
+item463,2.08863544179706,0.797876075876907,mieć  ma ,Czy Twoje dziecko mówi,mowa
+item464,5.50731236908928,-2.19478403348829,mieszkać,Czy Twoje dziecko mówi,mowa
+item465,4.1147529869201,-1.13398305685675,móc  może ,Czy Twoje dziecko mówi,mowa
+item466,5.68169396163354,-0.949500947825196,mówić powiedzieć,Czy Twoje dziecko mówi,mowa
+item467,4.82975096959884,-1.42489784586172,musieć  musi ,Czy Twoje dziecko mówi,mowa
+item468,3.42605051270859,1.27303386585456,myć  się ,Czy Twoje dziecko mówi,mowa
+item469,5.18721165274405,-2.86014388055752,myśleć,Czy Twoje dziecko mówi,mowa
+item470,4.83537994343099,-1.63251223382214,naprawiać reperować,Czy Twoje dziecko mówi,mowa
+item471,4.7860210851648,-1.5154193587335,nazywać się,Czy Twoje dziecko mówi,mowa
+item472,5.34722320421371,-1.59772625672311,nieść nosić,Czy Twoje dziecko mówi,mowa
+item473,5.8103673155716,-0.804215684054417,obudzić  się ,Czy Twoje dziecko mówi,mowa
+item474,5.84349120715277,-0.369965025206509,oglądać obejrzeć,Czy Twoje dziecko mówi,mowa
+item475,5.21438066472144,-2.03818918811587,opowiadać,Czy Twoje dziecko mówi,mowa
+item476,5.37938398431075,-0.521741753851766,otworzyć,Czy Twoje dziecko mówi,mowa
+item477,3.59263317436655,-1.31748068521192,palić  się ,Czy Twoje dziecko mówi,mowa
+item478,4.31147785496637,-0.515888677603169,patrzeć  patrz ,Czy Twoje dziecko mówi,mowa
+item479,2.66811994319651,2.02845931850353,pić,Czy Twoje dziecko mówi,mowa
+item480,3.8930041940799,0.313627419811686,pisać,Czy Twoje dziecko mówi,mowa
+item481,4.09587459237122,-2.02274000858087,pluć,Czy Twoje dziecko mówi,mowa
+item482,4.9946965870647,0.505378102431407,płakać,Czy Twoje dziecko mówi,mowa
+item483,5.18254895658863,-2.20840879403371,podobać się,Czy Twoje dziecko mówi,mowa
+item484,5.85958262616096,-1.33701042956217,pokazać,Czy Twoje dziecko mówi,mowa
+item485,5.79751039405517,-1.19118454134346,pomóc,Czy Twoje dziecko mówi,mowa
+item486,4.91615460504445,-3.09374194973606,pożyczyć,Czy Twoje dziecko mówi,mowa
+item487,5.19822181516358,-1.17653159027937,pracować,Czy Twoje dziecko mówi,mowa
+item488,4.5091267421827,-0.887677571703359,prać,Czy Twoje dziecko mówi,mowa
+item489,4.73214091677564,-1.94415140765711,prasować,Czy Twoje dziecko mówi,mowa
+item490,4.58405213925833,-0.484423851752489,prosić,Czy Twoje dziecko mówi,mowa
+item491,5.53418574432667,-1.2823648030091,przyjść,Czy Twoje dziecko mówi,mowa
+item492,5.41192449361201,-1.25065499787119,przykryć,Czy Twoje dziecko mówi,mowa
+item493,5.9262007715579,-1.31685235241377,przynieść,Czy Twoje dziecko mówi,mowa
+item494,4.3625003891497,-1.49823287243752,puścić,Czy Twoje dziecko mówi,mowa
+item495,5.28008145715461,-0.620870907228719,robić,Czy Twoje dziecko mówi,mowa
+item496,5.90968692660008,-1.77830274586162,rozmawiać,Czy Twoje dziecko mówi,mowa
+item497,4.67348964253067,0.160603439552395,rysować,Czy Twoje dziecko mówi,mowa
+item498,4.86984636110505,-0.724534680436165,rzucać,Czy Twoje dziecko mówi,mowa
+item499,6.17924677522229,-1.08634846140509,schować,Czy Twoje dziecko mówi,mowa
+item500,4.70284746884808,0.156524369824762,siedzieć,Czy Twoje dziecko mówi,mowa
+item501,4.20784954112232,0.337821671932025,skakać,Czy Twoje dziecko mówi,mowa
+item502,5.43988732588061,-2.38667479004298,skończyć,Czy Twoje dziecko mówi,mowa
+item503,6.11471456214759,-1.4955697167783,słyszeć słuchać,Czy Twoje dziecko mówi,mowa
+item504,3.02101757198439,1.96955566630642,spać,Czy Twoje dziecko mówi,mowa
+item505,5.88790488471263,0.005058812214746,sprzątać,Czy Twoje dziecko mówi,mowa
+item506,4.64660435283872,-0.51614871419722,stać,Czy Twoje dziecko mówi,mowa
+item507,3.93764138010521,-0.563093475633016,stukać pukać,Czy Twoje dziecko mówi,mowa
+item508,6.17690405681206,-0.647647609536482,szukać,Czy Twoje dziecko mówi,mowa
+item509,4.16361005199523,-2.63915126600376,szyć,Czy Twoje dziecko mówi,mowa
+item510,5.34419931391653,-0.621186538326175,śmiać się,Czy Twoje dziecko mówi,mowa
+item511,4.2161192987642,0.171369511895651,śpiewać,Czy Twoje dziecko mówi,mowa
+item512,4.0281546185307,0.774906642450744,tańczyć,Czy Twoje dziecko mówi,mowa
+item513,5.86649332256099,-1.17716695638084,trzymać,Czy Twoje dziecko mówi,mowa
+item514,5.7068282098277,-0.059807705912378,ubrać  się ,Czy Twoje dziecko mówi,mowa
+item515,5.79929277662594,-1.03277728818607,uciekać,Czy Twoje dziecko mówi,mowa
+item516,5.00262007934447,-1.95163446010247,uczyć się,Czy Twoje dziecko mówi,mowa
+item517,5.53329811094308,-1.71286154813362,umieć,Czy Twoje dziecko mówi,mowa
+item518,3.41004296712625,-0.394974330815415,upaść spaść,Czy Twoje dziecko mówi,mowa
+item519,4.9296265831372,-0.391257601853637,usiąść siadać,Czy Twoje dziecko mówi,mowa
+item520,4.86540721855613,-1.41696802853972,uściskać ukochać,Czy Twoje dziecko mówi,mowa
+item521,5.53892896176006,-2.89558387649404,wiązać,Czy Twoje dziecko mówi,mowa
+item522,5.33986751343096,-1.04547244131227,widzieć zobaczyć,Czy Twoje dziecko mówi,mowa
+item523,5.50930568845558,-2.42116646871324,wiedzieć,Czy Twoje dziecko mówi,mowa
+item524,5.83192940479666,-1.47907921913605,włożyć założyć,Czy Twoje dziecko mówi,mowa
+item525,5.06517279727709,-0.789477143667466,wstawać,Czy Twoje dziecko mówi,mowa
+item526,5.73259994368208,-0.866076242200739,wyrzucić,Czy Twoje dziecko mówi,mowa
+item527,5.76507645151082,-1.28427762750444,wytrzeć,Czy Twoje dziecko mówi,mowa
+item528,5.24879557240596,-1.22909324613355,zamiatać,Czy Twoje dziecko mówi,mowa
+item529,5.59421409872818,-0.457537119875893,zamknąć,Czy Twoje dziecko mówi,mowa
+item530,5.53365161952524,-1.68703914412726,zapiąć,Czy Twoje dziecko mówi,mowa
+item531,5.16735126606332,-0.879689081710848,zaświecić zapalić,Czy Twoje dziecko mówi,mowa
+item532,5.84183627167303,-1.25289647550425,zdjąć ściągnąć,Czy Twoje dziecko mówi,mowa
+item533,5.28293181522481,-0.704744676938634,zepsuć,Czy Twoje dziecko mówi,mowa
+item534,5.41493619512972,-1.54643678684074,zgubić,Czy Twoje dziecko mówi,mowa
+item535,5.77832098284508,-2.57861534242898,złamać,Czy Twoje dziecko mówi,mowa
+item536,6.59470531486282,-2.0623773775202,złapać,Czy Twoje dziecko mówi,mowa
+item537,6.16222208881549,-1.33650345696511,zmęczyć się,Czy Twoje dziecko mówi,mowa
+item538,5.01052809219646,-2.60151252517076,znać,Czy Twoje dziecko mówi,mowa
+item539,6.71143965823071,-2.2851149435442,znaleźć,Czy Twoje dziecko mówi,mowa
+item540,5.34957869252163,-1.86933159268436,zostać,Czy Twoje dziecko mówi,mowa
+item541,3.08390056046082,-0.069284217788466, nie  da się,Czy Twoje dziecko mówi,mowa
+item542,1.88514922422711,1.96861776354637,nie ma ,Czy Twoje dziecko mówi,mowa
+item543,3.75071140206213,-0.035200785964216, nie  można,Czy Twoje dziecko mówi,mowa
+item544,3.86000981924363,-1.31971622832019, nie  trzeba,Czy Twoje dziecko mówi,mowa
+item545,3.00069530673904,0.839476879521574, nie  wolno,Czy Twoje dziecko mówi,mowa
+item546,2.32182540460115,3.3307195703388,tu,Czy Twoje dziecko mówi,mowa
+item547,2.10112788689191,2.19644545703215,tam,Czy Twoje dziecko mówi,mowa
+item548,2.54589918453726,-1.49583468482598,tędy,Czy Twoje dziecko mówi,mowa
+item549,3.55822385076303,-3.20254007383648,stąd,Czy Twoje dziecko mówi,mowa
+item550,5.26270143394889,0.190543711953318,daleko,Czy Twoje dziecko mówi,mowa
+item551,4.99579125609004,-1.22876744854995,blisko,Czy Twoje dziecko mówi,mowa
+item552,4.13675899929735,0.435634095780853,wysoko,Czy Twoje dziecko mówi,mowa
+item553,3.82437078858112,-1.11427764118141,nisko,Czy Twoje dziecko mówi,mowa
+item554,3.94147618723834,0.466210447743276,na górę na górze,Czy Twoje dziecko mówi,mowa
+item555,3.92134229954218,-0.061978089532521,na dół na dole,Czy Twoje dziecko mówi,mowa
+item556,4.21383814191793,-1.76442681082143,z tyłu do tyłu,Czy Twoje dziecko mówi,mowa
+item557,4.32594443480895,-2.05782468194119,z przodu do przodu,Czy Twoje dziecko mówi,mowa
+item558,4.2039750291867,-2.06201599479768,w środku,Czy Twoje dziecko mówi,mowa
+item559,2.90257633768416,-1.69281470466508,gdzieś,Czy Twoje dziecko mówi,mowa
+item560,3.1576010930853,-1.90980332855641,nigdzie,Czy Twoje dziecko mówi,mowa
+item561,3.97988504381503,-2.90055337634268,wszędzie,Czy Twoje dziecko mówi,mowa
+item562,2.24253047570465,0.679780631145206,już już nie,Czy Twoje dziecko mówi,mowa
+item563,3.16487860783521,-0.058519344780676,jeszcze jeszcze nie,Czy Twoje dziecko mówi,mowa
+item564,3.48629480603137,0.017666073296681,teraz,Czy Twoje dziecko mówi,mowa
+item565,3.15864765401496,-0.886148926024031,zaraz,Czy Twoje dziecko mówi,mowa
+item566,3.45137790227929,-1.09159603528459,potem później,Czy Twoje dziecko mówi,mowa
+item567,4.1106406417328,-2.56618683744453,znowu znów,Czy Twoje dziecko mówi,mowa
+item568,4.11731025981056,-3.25322815216069,kiedyś,Czy Twoje dziecko mówi,mowa
+item569,3.40708031453775,-2.63519153768231,nigdy,Czy Twoje dziecko mówi,mowa
+item570,4.19729527530508,-3.12813168265165,zawsze,Czy Twoje dziecko mówi,mowa
+item571,3.93271298222589,-3.34072896942367,czasem,Czy Twoje dziecko mówi,mowa
+item572,3.97800736409541,-0.41051198898356,dzisiaj dziś,Czy Twoje dziecko mówi,mowa
+item573,3.71453994760591,-0.59083236299397,jutro,Czy Twoje dziecko mówi,mowa
+item574,4.09068060739974,-1.7823237818834,wczoraj,Czy Twoje dziecko mówi,mowa
+item575,3.82338272262067,-0.775585128033938,rano,Czy Twoje dziecko mówi,mowa
+item576,4.00451220245436,-1.87763468572541,wieczorem,Czy Twoje dziecko mówi,mowa
+item577,3.93276062033656,-0.270408731191686,noc w nocy,Czy Twoje dziecko mówi,mowa
+item578,4.05101318710924,-0.783877841901274,dzień,Czy Twoje dziecko mówi,mowa
+item579,3.78754282024472,-2.1064274438187,godzina,Czy Twoje dziecko mówi,mowa
+item580,4.65476757521312,2.00763865732202,dużo,Czy Twoje dziecko mówi,mowa
+item581,3.96750621952953,1.0766554331324,mało,Czy Twoje dziecko mówi,mowa
+item582,4.00774931256757,-1.3366320716577,trochę troszkę,Czy Twoje dziecko mówi,mowa
+item583,2.5316810471164,-1.10064746332014,tyle,Czy Twoje dziecko mówi,mowa
+item584,4.49674760222469,-2.17244927104697,więcej,Czy Twoje dziecko mówi,mowa
+item585,3.10479246543203,0.405136494088475,jeszcze,Czy Twoje dziecko mówi,mowa
+item586,4.64220106056981,-1.94014440382921,wszystko wszyscy,Czy Twoje dziecko mówi,mowa
+item587,2.97481643481967,-1.01578418591871,inny,Czy Twoje dziecko mówi,mowa
+item588,3.10097394746448,-0.746597569175617,drugi,Czy Twoje dziecko mówi,mowa
+item589,3.94583777056493,-1.30040234723223,cały,Czy Twoje dziecko mówi,mowa
+item590,4.48531858036306,-1.330881611216,bardzo,Czy Twoje dziecko mówi,mowa
+item591,4.76546359899615,-2.34461645819543,tylko,Czy Twoje dziecko mówi,mowa
+item592,2.69729944951679,1.00904699922499,sam sama,Czy Twoje dziecko mówi,mowa
+item593,4.36688959156583,-1.36851174497387,razem,Czy Twoje dziecko mówi,mowa
+item594,2.70871448115984,-0.962594285827408,też,Czy Twoje dziecko mówi,mowa
+item595,2.45127802892123,-1.43427736609229,dosyć dość,Czy Twoje dziecko mówi,mowa
+item596,3.38182545831285,-1.26121530343181,za  np  za dużo ,Czy Twoje dziecko mówi,mowa
+item597,4.20855586154414,-3.30576530975393,każdy,Czy Twoje dziecko mówi,mowa
+item598,3.73158699271382,-4.33521340958653,niektóry,Czy Twoje dziecko mówi,mowa
+item599,3.93034136190098,-3.63672421434391,żaden,Czy Twoje dziecko mówi,mowa
+item600,2.12414162298577,2.48331262361921,ja  mi  mnie ,Czy Twoje dziecko mówi,mowa
+item601,2.39124093540468,0.990615735687325,ty  ci  cię ,Czy Twoje dziecko mówi,mowa
+item602,2.30054959039331,-0.276657345618966,on  mu  go ,Czy Twoje dziecko mówi,mowa
+item603,2.7304824247366,-0.796304339540789,ona  jej  ją ,Czy Twoje dziecko mówi,mowa
+item604,2.92602725308987,-0.898556991294082,my  nam  nas ,Czy Twoje dziecko mówi,mowa
+item605,2.9369876810458,-2.01534584887471,wy  wam  was ,Czy Twoje dziecko mówi,mowa
+item606,2.87652708193284,-2.03848046131396,oni one  im  ich je ,Czy Twoje dziecko mówi,mowa
+item607,2.72356573515742,-2.5305033697548,się,Czy Twoje dziecko mówi,mowa
+item608,2.97722732278531,-3.16452308720936,sobie,Czy Twoje dziecko mówi,mowa
+item609,2.78215386822413,1.12594494460027,mój,Czy Twoje dziecko mówi,mowa
+item610,3.32312756037512,-0.704452054848642,twój,Czy Twoje dziecko mówi,mowa
+item611,2.89225570625681,-2.11744646496608,jego,Czy Twoje dziecko mówi,mowa
+item612,2.77168911468943,-2.06891824038173,jej,Czy Twoje dziecko mówi,mowa
+item613,3.29926888052457,-1.60129475446621,nasz,Czy Twoje dziecko mówi,mowa
+item614,3.32332096104609,-3.12330433420269,wasz,Czy Twoje dziecko mówi,mowa
+item615,3.23484155205021,-3.25298229755413,ich,Czy Twoje dziecko mówi,mowa
+item616,3.13524102745548,-3.12590760192462,swój,Czy Twoje dziecko mówi,mowa
+item617,1.97029329381214,2.41096272693798,to,Czy Twoje dziecko mówi,mowa
+item618,2.7563490462606,-0.819236618496971,coś,Czy Twoje dziecko mówi,mowa
+item619,3.12446764356246,-1.53742436908188,ktoś,Czy Twoje dziecko mówi,mowa
+item620,2.45853540990221,0.629046061388881,nic,Czy Twoje dziecko mówi,mowa
+item621,3.65154046990632,-2.25020506641213,nikt,Czy Twoje dziecko mówi,mowa
+item622,2.00367066499904,0.002881364099064,ten,Czy Twoje dziecko mówi,mowa
+item623,2.97752389555514,-2.07086218429843,tamten,Czy Twoje dziecko mówi,mowa
+item624,2.91826592257141,-1.00204651271898,taki,Czy Twoje dziecko mówi,mowa
+item625,3.73831910323831,-2.96384901655936,jakiś,Czy Twoje dziecko mówi,mowa
+item626,2.61420239000496,1.51133166266881,co to  co to jest ,Czy Twoje dziecko mówi,mowa
+item627,2.16741751754379,0.942324677794988,co ,Czy Twoje dziecko mówi,mowa
+item628,4.42939879530899,-0.229289195828978,co robi ,Czy Twoje dziecko mówi,mowa
+item629,3.16459714111685,0.180270180066289,kto ,Czy Twoje dziecko mówi,mowa
+item630,3.63626290816973,-2.46898266696096,czyj ,Czy Twoje dziecko mówi,mowa
+item631,3.54615768935942,0.254496682914037,gdzie ,Czy Twoje dziecko mówi,mowa
+item632,4.33372771524065,-1.71633693298433,kiedy ,Czy Twoje dziecko mówi,mowa
+item633,3.39286874751803,-1.11535865388474,jak ,Czy Twoje dziecko mówi,mowa
+item634,4.16304827879897,-1.13513109067046,dlaczego czemu ,Czy Twoje dziecko mówi,mowa
+item635,3.34321783385807,-0.969832150894513,po co na co ,Czy Twoje dziecko mówi,mowa
+item636,3.87564289829871,-1.22956766104818,jaki ,Czy Twoje dziecko mówi,mowa
+item637,4.07571766914641,-2.52030052338867,który ,Czy Twoje dziecko mówi,mowa
+item638,3.46834288441519,-1.45311271629135,ile ,Czy Twoje dziecko mówi,mowa
+item639,3.05388423303913,-1.36882712836908,chyba,Czy Twoje dziecko mówi,mowa
+item640,3.23468169760692,-1.34834246531652,może,Czy Twoje dziecko mówi,mowa
+item641,3.67008668305598,-2.88122737743377,na pewno,Czy Twoje dziecko mówi,mowa
+item642,3.51131603274844,-2.3164059352171,naprawdę,Czy Twoje dziecko mówi,mowa
+item643,3.25123499380902,-2.95220726961409,pewnie,Czy Twoje dziecko mówi,mowa
+item644,3.58381256932076,-3.28207540539954,przecież,Czy Twoje dziecko mówi,mowa
+item645,3.08088244432375,-3.22411897394949,w ogóle,Czy Twoje dziecko mówi,mowa
+item646,3.36652938559125,-2.68012227671068,właśnie,Czy Twoje dziecko mówi,mowa
+item647,3.33180936436893,-0.508419562102019,bez,Czy Twoje dziecko mówi,mowa
+item648,3.7795557475227,0.287610727917607,dla,Czy Twoje dziecko mówi,mowa
+item649,3.48991904296224,0.863051122850386,do,Czy Twoje dziecko mówi,mowa
+item650,3.4516953540871,0.345507087299581,na,Czy Twoje dziecko mówi,mowa
+item651,3.62341746799104,-1.54067998530869,koło obok,Czy Twoje dziecko mówi,mowa
+item653,3.90813888607106,-0.405049008169332,od,Czy Twoje dziecko mówi,mowa
+item654,3.45302002684564,-1.02803070595076,po,Czy Twoje dziecko mówi,mowa
+item655,3.8954633198572,-1.04673685181349,pod,Czy Twoje dziecko mówi,mowa
+item656,4.14503705468109,-2.72687998908128,przed,Czy Twoje dziecko mówi,mowa
+item657,2.96829569427949,0.047270261789659,u,Czy Twoje dziecko mówi,mowa
+item658,3.79524255036758,-0.27694537201806,w,Czy Twoje dziecko mówi,mowa
+item659,3.40339975767652,-1.34070085598879,za,Czy Twoje dziecko mówi,mowa
+item660,3.38587080002141,0.140137699149503,z  np  tatusiem ,Czy Twoje dziecko mówi,mowa
+item661,3.50542988624035,-1.15249730956484,z  np  łazienki ,Czy Twoje dziecko mówi,mowa
+item662,1.33766224937188,0.046276606100065,a,Czy Twoje dziecko mówi,mowa
+item663,3.35428733748693,-2.15925051321118,albo,Czy Twoje dziecko mówi,mowa
+item664,2.91139529750237,-1.32266007774134,ale,Czy Twoje dziecko mówi,mowa
+item665,2.46517042069038,-0.841428547431307,bo,Czy Twoje dziecko mówi,mowa
+item666,2.02541433612221,0.022807458631044,i,Czy Twoje dziecko mówi,mowa
+item667,3.01966067883373,-1.7032215457634,jak    to ,Czy Twoje dziecko mówi,mowa
+item668,3.72160552003402,-2.09191448828567,tylko,Czy Twoje dziecko mówi,mowa
+item669,3.19067065565046,-2.16355953279261,że,Czy Twoje dziecko mówi,mowa
+item670,3.7737213144783,-3.15319725013097,żeby,Czy Twoje dziecko mówi,mowa

--- a/www/languages/pl/forms/adaptive/ws-cat/settings&translations.csv
+++ b/www/languages/pl/forms/adaptive/ws-cat/settings&translations.csv
@@ -1,6 +1,10 @@
 text_type;text
-MirtMethod;ML
-MirtCriteria;MI
-minItemNr;1
-maxItemNr;5
-MirtSeTheta;0.05
+cdiNameSufix;Wersja adaptatywna dla rodziców starszych dzieci
+groups;mowa
+mowaMirtMethod;ML
+mowaMirtCriteria;MI
+mowaminItemNr;1
+mowamaxItemNr;5
+mowaMirtSeTheta;0.05
+mowaInstr;"Po kliknięciu przycisku ‚Dalej’ zobaczą Państwo kolejne słowa i przy każdym będą Państwo proszeni o odpowiedź na pytanie, czy Państwa dziecko mówi to słowo spontanicznie. Nie chodzi o to, co dziecko jest w stanie powtórzyć, ale o słowa, których samo z siebie używa. Proszę zaznaczyć ‚tak’ tylko przy tych słowach, które słyszeli Państwo od swego dziecka. Jeżeli dziecko używa nieco innej formy, np. mówi „piesek”, a nie „pies”, proszę mimo to zaznaczyć ‚tak’ przy słowie „pies”. Tak samo należy postąpić, jeśli dziecko wymawia jakieś słowo inaczej (np. „lybka” zamiast „rybka” lub „wiójka” zamiast „wiewiórka”). Proszę wtedy również zaznaczyć ‚tak’. Czasami dzieci wymyślają własne wyrazy, np. „dzi” zamiast „piłka”; także taką formę należy potraktować jako wyraz i zaznaczyć ‚tak’ przy słowie „piłka”. Podobnie, jeśli w rodzinie funkcjonuje inne określenie niż podane w kwestionariuszu, proszę zaznaczyć odpowiednią pozycję. Jeśli będą Państwo chcieli, w polu na uwagi, które pojawi się na końcu, mogą Państwo wpisać wszystkie te wyrazy w takiej formie, w jakiej ich Państwa dziecko używa. Mogą Państwo również wykorzystać to pole, żeby podzielić się z nami wszelkimi wątpliwości. Proszę pamiętać, że IRMIK opiera się na wiedzy rodziców (lub innych opiekunów) na temat rozwoju językowego dzieci. Proszę nie przepytywać dziecka ani go nie prosić o powtarzanie poszczególnych wyrazów. Wystarczy, gdy odpowiedzą Państwo na pytania według własnej wiedzy o dziecku."
+continueBtn;Dalej


### PR DESCRIPTION
Zdaje się, że ten merge jest bezbolesny i w ogóle nie potrzebowałem robić oddzielnego branchu. Mam tylko prośbę, żebyś po uporaniu się ze #196 dodała w odpowiednich miejscach teksty wprowadzające w poniższym brzmieniu:

SIG(WG):

> Kilka dni temu prosiliśmy Państwa o wypełnienie IRMIKa — kwestionariusza, w którym rodzice (lub inni opiekunowie) zaznaczają na liście słów te, które ich dziecko rozumie lub nawet samo mówi, a na liście gestów te, za pomocą których ich dziecko się porozumiewa. Jest to prosta i uznana na świecie metoda badania rozwoju mowy i komunikacji małych dzieci. Ma niestety jednak jedną istotną wadę: listy wyrazów i gestów są długie i wypełnienie całego inwentarza jest w związku z tym bardzo żmudne i czasochłonne. Opracowaliśmy więc nowoczesną, tzw. adaptatywną, wersję IRMIKa, w której kolejny wyraz lub gest wybierany jest przez komputer na podstawie dotychczasowych odpowiedzi w taki sposób, żeby jak najlepiej „dopasować się” do danego dziecka. Dzięki temu osoby wypełniające IRMIKa nie muszą przeglądać pełnej listy. Wystarczy kilkadziesiąt, a czasem nawet kilkanaście słów lub gestów, co skraca czas wypełniania do zaledwie kilku minut! Porównując odpowiedzi, o które zaraz Państwa poprosimy, z tymi, których udzielili Państwo w pełnej wersji, będziemy mogli ocenić, na ile adaptatywne IRMIKi będą mogły w przyszłości zastąpić wersje tradycyjne.

SIZ(WS):

> Kilka dni temu prosiliśmy Państwa o wypełnienie IRMIKa — kwestionariusza, w którym rodzice (lub inni opiekunowie) zaznaczają na liście słów te, które ich dziecko zna. Jest to prosta i uznana na świecie metoda badania rozwoju mowy małych dzieci. Ma niestety jednak jedną istotną wadę: lista wyrazów jest bardzo długa i wypełnienie całego inwentarza jest w związku z tym bardzo żmudne i czasochłonne. Opracowaliśmy więc nowoczesną, tzw. adaptatywną, wersję IRMIKa, w której kolejny wyraz wybierany jest przez komputer na podstawie dotychczasowych odpowiedzi w taki sposób, żeby jak najlepiej „dopasować się” do danego dziecka. Dzięki temu osoby wypełniające IRMIKa nie muszą przeglądać pełnej listy kilkuset słów. Wystarczy kilkadziesiąt, a czasem nawet kilkanaście, co skraca czas wypełniania do zaledwie kilku minut! Porównując odpowiedzi, o które zaraz Państwa poprosimy, z tymi, których udzielili Państwo w pełnej wersji, będziemy mogli ocenić, na ile adaptatywne IRMIKi będą mogły w przyszłości zastąpić wersje tradycyjne.
